### PR TITLE
chore: adding dev advocate bios

### DIFF
--- a/website/docs/working-group/readme.md
+++ b/website/docs/working-group/readme.md
@@ -38,11 +38,35 @@ Our current quarterly initiative focused on creating a clear entry path for newc
 - **Duration**: 1 hour per session
 - **Recording**: All sessions recorded for asynchronous access
 
-### Presenters
-- **Tyty** - Lead coordinator and technical sessions
-- **Uche** - Community building and contribution focus
-- **Dan** - Technical workshops and troubleshooting
-- **Harun** - Developer stories and ecosystem overview
+### Developer Advocates
+
+**[Dan Baruka](https://www.linkedin.com/in/danbaruka/)**  
+Dan Baruka is a Developer Advocate at Intersect and co-founder of Uptodate Developers, where he leads initiatives focused on strengthening developer engagement and advancing blockchain innovation. A Cardano Ambassador since 2021, he is passionate about empowering developers through education, hands-on collaboration, and real-world adoption of decentralized technologies.
+
+With a strong background in DevOps, software engineering, and blockchain systems, he has directed numerous projects across fintech, education, and decentralized applications, including platforms such as AdaEx and DevCommunityIo. Beyond development, he is an active article writer, meetup organizer, workshop facilitator, and hackathon leader, driving community growth and technical awareness across Africa and beyond.
+
+His leadership combines deep technical expertise with a strong commitment to open collaboration, infrastructure reliability, and developer experience, helping make Cardano and Web3 technologies more accessible to builders worldwide.
+
+**[Uchechukwu Obasi (Uche)](https://www.linkedin.com/in/thisisobate)**  
+Uchechukwu Obasi is a Software Engineer passionate about open source, developer experience, and community building. He currently serves as a Developer Advocate at Intersect, where he helps grow and support the global Cardano developer ecosystem.
+
+Uchechukwu focuses on empowering developers through education, technical content, and advocacy — helping new and existing contributors navigate the ecosystem and build impactful projects on Cardano.
+
+He is also an active speaker and community mentor, dedicated to fostering inclusive spaces where developers can learn, collaborate, and innovate together.
+
+**[Harun Waweru Mwangi](https://www.linkedin.com/in/harunslinked/)**  
+Harun Waweru Mwangi is a driven Developer Advocate and blockchain entrepreneur with over 15 years of experience spanning business operations and Web3 development. As Co-founder of Tx-Meta and Software/Smart Contract Developer at Anastasia Labs, he combines deep technical expertise with visionary leadership to empower developers building on Cardano.
+
+A Certified Cardano Solutions Architect from EMURGO Academy and Plutus Pioneer Program alumnus, Harun has established himself as a key ecosystem advocate through his role as former SmartBlocks Ambassador and EMURGO Academy Social Media Manager. His technical portfolio includes the Zao Crypto On/Off-ramp App for African markets, and he is driving innovation through the DCU Protocol to transform traditional savings groups into decentralized credit unions.
+
+Harun's advocacy work focuses on onboarding new developers and driving adoption through education and mentorship. He is passionate about making Cardano accessible to builders across Africa while demonstrating blockchain's potential for solving real-world problems.
+
+**[Emmanuel Titi](https://www.linkedin.com/in/emmanuel-shikuku-devops/)**  
+Emmanuel Titi is a Developer Advocate at Intersect, dedicated to empowering developers within the Cardano ecosystem. His work focuses on onboarding new contributors, maintaining and improving technical documentation across core repositories, and driving developer evangelism through open collaboration and education.
+
+With a strong background in full-stack and DevOps engineering, Emmanuel has been a key contributor to open-source Cardano projects such as Catalyst Explorer and Govtool Outcomes Pillar. Before joining Intersect, he led development at Lidonation, where he built Cardano-integrated learning and reward platforms, NFT minting tools, and crypto payment packages.
+
+Passionate about open-source development, Emmanuel advocates for a inclusive, and well-documented developer experience helping make Cardano more accessible to builders around the world.
 
 ## Goals for Q1 2025
 


### PR DESCRIPTION

**Description**

Updates the Developer Advocates section in the working group documentation with comprehensive biographies and LinkedIn profiles.

**Type of Change**
Documentation update

**Changes Made**
•  Updated: website/docs/working-group/readme.md - Replaced basic "Presenters" section with detailed "Developer Advocates" section featuring comprehensive biographies and LinkedIn links for Dan Baruka, Uchechukwu Obasi (Uche), Harun Waweru Mwangi, and Emmanuel Titi