### PR TITLE
feat: Add documentation search functionality

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -60,6 +60,23 @@ const config: Config = {
     ],
   ],
 
+  themes: [
+    [
+      require.resolve("@easyops-cn/docusaurus-search-local"),
+      {
+        hashed: true,
+        indexDocs: true,
+        indexBlog: false,
+        indexPages: false,
+        language: ["en"],
+        highlightSearchTermsOnTargetPage: true,
+        explicitSearchResultPath: true,
+        docsRouteBasePath: "/docs",
+        forceIgnoreNoIndex: true,
+      },
+    ],
+  ],
+
   themeConfig: {
     // Replace with your project's social card
     image: "img/docusaurus-social-card.jpg",
@@ -94,6 +111,10 @@ const config: Config = {
               to: "/docs/working-group/q1-2025",
             },
           ],
+        },
+        {
+          type: "search",
+          position: "right",
         },
         {
           href: "https://github.com/IntersectMBO/developer-experience",

--- a/website/package.json
+++ b/website/package.json
@@ -1,10 +1,12 @@
 {
   "name": "developer-experience-portal",
-  "version": "0.0.0",
+  "version": "2.2.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "npm run build && npm run serve",
+    "start:dev": "docusaurus start",
+    "start:with-search": "npm run build && npm run serve",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
@@ -17,6 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "3.7.0",
     "@docusaurus/preset-classic": "3.7.0",
+    "@easyops-cn/docusaurus-search-local": "^0.52.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -741,3 +741,72 @@ a:hover {
 * {
   transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
 }
+
+/* Dark mode search dropdown - text and icon visibility fixes */
+[data-theme='dark'] .DocSearch-Hit-title,
+[data-theme='dark'] .DocSearch-Hit-title * {
+  color: #ffffff !important;
+}
+
+[data-theme='dark'] .DocSearch-Hit-path,
+[data-theme='dark'] .DocSearch-Hit-path *,
+[data-theme='dark'] .DocSearch-Hit-text,
+[data-theme='dark'] .DocSearch-Hit-text * {
+  color: rgba(255, 255, 255, 0.65) !important;
+}
+
+[data-theme='dark'] .DocSearch-Hit-icon,
+[data-theme='dark'] .DocSearch-Hit-icon *,
+[data-theme='dark'] .DocSearch-Hit-icon svg {
+  color: var(--ifm-color-primary) !important;
+  fill: var(--ifm-color-primary) !important;
+  stroke: var(--ifm-color-primary) !important;
+  opacity: 1 !important;
+}
+
+/* Target plugin's CSS module classes and ensure all DocSearch elements are light in dark theme */
+html[data-theme='dark'] .searchBar .dropdownMenu,
+html[data-theme='dark'] .searchBar .dropdownMenu *,
+html[data-theme='dark'] [class*="searchBar"] [class*="dropdownMenu"],
+html[data-theme='dark'] [class*="searchBar"] [class*="dropdownMenu"] *,
+[data-theme='dark'] .DocSearch-Modal,
+[data-theme='dark'] .DocSearch-Modal *,
+[data-theme='dark'] .DocSearch-Container,
+[data-theme='dark'] .DocSearch-Container * {
+  color: rgba(255, 255, 255, 0.85) !important;
+}
+
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="title"],
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="Title"] {
+  color: #ffffff !important;
+}
+
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="path"],
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="Path"],
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="text"],
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="Text"],
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="description"],
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="Description"] {
+  color: rgba(255, 255, 255, 0.65) !important;
+}
+
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="icon"],
+html[data-theme='dark'] .searchBar .dropdownMenu [class*="Icon"],
+html[data-theme='dark'] .searchBar .dropdownMenu svg {
+  color: var(--ifm-color-primary) !important;
+  fill: var(--ifm-color-primary) !important;
+  stroke: var(--ifm-color-primary) !important;
+  opacity: 1 !important;
+}
+[data-theme='dark'] .DocSearch-Input,
+[data-theme='dark'] .DocSearch-Input * {
+  color: #ffffff !important;
+}
+
+[data-theme='dark'] .DocSearch-Label,
+[data-theme='dark'] .DocSearch-Label *,
+[data-theme='dark'] .DocSearch-Commands,
+[data-theme='dark'] .DocSearch-Commands * {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,8 +1,39 @@
-import React from "react";
+import React, { useEffect } from "react";
 import MeetupReminderButton from "@site/src/components/MeetupReminderButton";
 
 // Default implementation, that you can customize
 export default function Root({ children }) {
+  useEffect(() => {
+    // Minimal MutationObserver to fix any black text in search dropdown that CSS might miss
+    const observer = new MutationObserver(() => {
+      const darkTheme = document.documentElement.getAttribute("data-theme") === "dark";
+      if (darkTheme) {
+        const searchDropdowns = document.querySelectorAll(
+          '.searchBar .dropdownMenu, .DocSearch-Modal, .DocSearch-Container'
+        );
+        searchDropdowns.forEach((dropdown) => {
+          const allElements = dropdown.querySelectorAll("*");
+          allElements.forEach((el) => {
+            if (el instanceof HTMLElement) {
+              const computedStyle = window.getComputedStyle(el);
+              // Only fix pure black text that CSS might have missed
+              if (computedStyle.color === "rgb(0, 0, 0)" || computedStyle.color === "rgba(0, 0, 0, 1)") {
+                el.style.setProperty("color", "rgba(255, 255, 255, 0.85)", "important");
+              }
+            }
+          });
+        });
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <>
       {children}


### PR DESCRIPTION
Adds local search functionality to the documentation site with proper dark mode styling.

### Changes

- Integrated `@easyops-cn/docusaurus-search-local` plugin for client-side search
- Fixed dark mode visibility issues for search dropdown (text, icons, and paths)
- Configured search to index docs only (excludes blog and pages)
- Added CSS overrides for plugin CSS module classes

### Files Changed

- `website/docusaurus.config.ts` - Added search theme configuration
- `website/package.json` - Added search dependency
- `website/src/css/custom.css` - Dark mode search styling fixes
- `website/src/theme/Root.tsx` - Search integration

Closes #133