### PR TITLE
fix: resolve Jump to Top button overlap with DevEx Sessions (#170)

### DIFF
--- a/website/src/components/MeetupReminderButton/styles.module.css
+++ b/website/src/components/MeetupReminderButton/styles.module.css
@@ -1,8 +1,9 @@
 /* Container for the entire component */
 .container {
   position: fixed;
-  bottom: 2rem;
-  right: 2rem;
+  bottom: 1rem;
+  right: 1.5rem;
+
   z-index: 9999;
   font-family: var(--ifm-font-family-base);
 }
@@ -78,6 +79,7 @@
     opacity: 0;
     transform: translateY(10px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -573,12 +575,17 @@
   color: var(--ifm-color-primary-light);
 }
 
-/* Responsive Design */
-@media (max-width: 768px) {
+
+/* Desktop (≥768px): DevEx Sessions (Meetup) at bottom-right corner, to the right of Jump to Top, same baseline */
+@media (min-width: 768px) {
   .container {
-    bottom: 1rem;
-    right: 1rem;
+    right: 2rem;
+    bottom: 2rem;
   }
+}
+
+@media (max-width: 768px) {
+
 
   .panel {
     bottom: 4.5rem;
@@ -625,7 +632,7 @@
 @media (max-width: 480px) {
   .container {
     bottom: 0.75rem;
-    right: 0.75rem;
+    right: 1.5rem;
   }
 
   .floatingButton {
@@ -666,6 +673,7 @@
 
 /* Accessibility - High Contrast Mode */
 @media (prefers-contrast: high) {
+
   .floatingButton,
   .linkButton,
   .calendarButton {
@@ -679,6 +687,7 @@
 
 /* Reduced Motion Support */
 @media (prefers-reduced-motion: reduce) {
+
   .floatingButton,
   .linkButton,
   .calendarButton,
@@ -688,6 +697,7 @@
   }
 
   @keyframes slideUp {
+
     from,
     to {
       opacity: 1;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -986,3 +986,19 @@ html[data-theme='dark'] .searchBar .dropdownMenu svg {
 [data-theme='dark'] .DocSearch-Commands * {
   color: rgba(255, 255, 255, 0.7) !important;
 }
+
+/* Jump to Top above DevEx Sessions (Meetup), same right alignment */
+@media (max-width: 767px) {
+  .theme-back-to-top-button {
+    bottom: 4.9rem !important;
+    right: 1.7rem !important;
+  }
+}
+
+/* Jump to Top to the left of DevEx Sessions (Meetup), same baseline */
+@media (min-width: 767px) {
+  .theme-back-to-top-button {
+    bottom: 2.2rem !important;
+    right: 11rem !important;
+  }
+}


### PR DESCRIPTION
### Description
Fixes the overlap between the "Jump to Top" and "Meetup" buttons in the bottom-right corner. Uses a responsive layout so both stay visible: on mobile, Jump to Top is above Meetup; on desktop, Jump to Top is to the left of Meetup.

[Related to #170](https://github.com/IntersectMBO/developer-experience/issues/170)

### Changes Made
Mobile (< 768px): Jump to Top above Meetup, same right alignment; Meetup at bottom-right.
Desktop (≥ 768px): Jump to Top to the left of Meetup; both on the same baseline.
Files modified: `src/MeetupReminderButton/styles.module.css`, `src/css/custom.css`

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Testing
- [x] I have tested these changes locally
- [ ] I have checked for broken links
- [ ] Code examples have been tested

### Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings