### PR TITLE
fix: rename floating button label from Meetup to DevEx Sessions (#171)

### DIFF
--- a/website/src/components/MeetupReminderButton/index.tsx
+++ b/website/src/components/MeetupReminderButton/index.tsx
@@ -66,7 +66,7 @@ const MeetupReminderButton: React.FC<MeetupReminderButtonProps> = ({
         }`}
         onClick={() => setIsExpanded(!isExpanded)}
         onKeyDown={handleKeyDown}
-        aria-label="Toggle meetup reminder"
+        aria-label="Toggle DevEx Sessions"
         aria-expanded={isExpanded}
         aria-controls="meetup-panel"
         type="button"
@@ -109,7 +109,7 @@ const MeetupReminderButton: React.FC<MeetupReminderButtonProps> = ({
             strokeLinejoin="round"
           />
         </svg>
-        <span className={styles.buttonText}>Meetup</span>
+        <span className={styles.buttonText}>DevEx Sessions</span>
       </button>
 
       {isExpanded && (
@@ -118,11 +118,11 @@ const MeetupReminderButton: React.FC<MeetupReminderButtonProps> = ({
           id="meetup-panel"
           className={styles.panel}
           role="dialog"
-          aria-label="Meetup information panel"
+          aria-label="DevEx Sessions information panel"
         >
           <div className={styles.panelHeader}>
             <h3 className={styles.panelTitle}>
-              {selectedSession ? currentSession?.name : "Select a Meetup"}
+              {selectedSession ? currentSession?.name : "Select a DevEx Session"}
             </h3>
             <button
               className={styles.closeButton}
@@ -130,7 +130,7 @@ const MeetupReminderButton: React.FC<MeetupReminderButtonProps> = ({
                 setIsExpanded(false);
                 setSelectedSession(null);
               }}
-              aria-label="Close meetup panel"
+              aria-label="Close DevEx Sessions panel"
               type="button"
             >
               <svg


### PR DESCRIPTION
### Description
Renames the floating button label from "Meetup" to "DevEx Sessions" so it reflects Developer Experience sessions instead of meetups.
Related to #171

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (improves code structure or readability without changing functionality)

### Changes Made
Button label: "Meetup" → "DevEx Sessions"
Panel title: "Select a Meetup" → "Select a DevEx Session"
aria-labels: Updated for accessibility (Toggle, panel, close button)
Files modified: `src/MeetupReminderButton/index.tsx`

### Testing
- [x] I have tested these changes locally
- [ ] I have checked for broken links
- [ ] Code examples have been tested

### Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings