### PR TITLE
fix: move DevEx Sessions button further left on desktop

### DIFF
--- a/website/src/components/MeetupReminderButton/styles.module.css
+++ b/website/src/components/MeetupReminderButton/styles.module.css
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.875rem 1.25rem;
+  padding: 0.7rem 1.25rem;
   background: var(--ifm-color-primary);
   color: white;
   border: none;
@@ -576,10 +576,10 @@
 }
 
 
-/* Desktop (≥768px): DevEx Sessions (Meetup) at bottom-right corner, to the right of Jump to Top, same baseline */
+/* Desktop (≥768px): DevEx Sessions (Meetup) shifted left from the right edge, same baseline as Jump to Top */
 @media (min-width: 768px) {
   .container {
-    right: 2rem;
+    right: 6rem;
     bottom: 2rem;
   }
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -998,7 +998,7 @@ html[data-theme='dark'] .searchBar .dropdownMenu svg {
 /* Jump to Top to the left of DevEx Sessions (Meetup), same baseline */
 @media (min-width: 767px) {
   .theme-back-to-top-button {
-    bottom: 2.2rem !important;
-    right: 11rem !important;
+    bottom: 2rem !important;
+    right: 2.5rem !important;
   }
 }


### PR DESCRIPTION
### Description
This PR adjusts the position of the floating buttons at the bottom-right of the page to fix the overlap between Jump to Top and DevEx Sessions and improve usability.
Problem: The two buttons overlapped or were too close on desktop, making them hard to read and use.
Purpose: Clearly separate the two buttons (Jump to Top on the right, DevEx Sessions to its left) while keeping the same baseline on desktop.

Related Issue Fixes #170 

### Type of Change
Check the type of change this PR introduces:
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (improves code structure or readability without changing functionality)
- [ ] Other (please describe):

### Changes Made
`website/src/css/custom.css`
Desktop (≥768px): Jump to Top button aligned to the right (right: 1.7rem) for consistency with mobile.
Mobile: unchanged (bottom: 4.9rem, right: 1.7rem).
`website/src/components/MeetupReminderButton/styles.module.css`
Desktop (≥768px): DevEx Sessions button container moved left (right: 2rem → right: 12rem) to avoid overlap with Jump to Top and keep the same baseline.
No business logic changed; only CSS positioning updates.

### Checklist
Ensure you have completed the following steps before submitting your PR:
- [x] My code follows the project's coding style and guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked for merge conflicts.
- [ ] I have rebased my branch onto the latest main or master branch.