### PR TITLE
Implement text auto resize component for best label rendering on small device

### DIFF
--- a/website/src/theme/DocSidebarItem/Category/index.tsx
+++ b/website/src/theme/DocSidebarItem/Category/index.tsx
@@ -1,0 +1,339 @@
+/**
+ * Custom category item used by the docs sidebar.  Only a small portion of the
+ * original file is modified: the label rendering.  We truncate long labels and
+ * add a tooltip so the UI doesn't break on mobile.
+ *
+ * The rest of this component is copied verbatim from the upstream theme so that
+ * behavior remains compatible with future releases; updates can be pulled in by
+ * re‑swizzling or diffing against the official source.
+ */
+
+import React, {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useMemo,
+} from 'react';
+import clsx from 'clsx';
+import {
+  ThemeClassNames,
+  useThemeConfig,
+  usePrevious,
+  Collapsible,
+  useCollapsible,
+} from '@docusaurus/theme-common';
+import {isSamePath} from '@docusaurus/theme-common/internal';
+import {
+  isActiveSidebarItem,
+  findFirstSidebarItemLink,
+  useDocSidebarItemsExpandedState,
+  useVisibleSidebarItems,
+} from '@docusaurus/plugin-content-docs/client';
+import Link from '@docusaurus/Link';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import {translate} from '@docusaurus/Translate';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import DocSidebarItems from '@theme/DocSidebarItems';
+import DocSidebarItemLink from '@theme/DocSidebarItem/Link';
+import type {Props} from '@theme/DocSidebarItem/Category';
+
+import type {
+  PropSidebarItemCategory,
+  PropSidebarItemLink,
+} from '@docusaurus/plugin-content-docs';
+import styles from './styles.module.css';
+
+// same helper used in Link component
+const MAX_LABEL_LENGTH = 25;
+function truncateText(label: string) {
+  if (label.length <= MAX_LABEL_LENGTH) {
+    return label;
+  }
+  return label.substring(0, MAX_LABEL_LENGTH - 3) + '...';
+}
+
+function CategoryLinkLabel({label}: {label: string}) {
+  const display = truncateText(label);
+  return (
+    <span title={label} className={styles.categoryLinkLabel}>
+      {display}
+    </span>
+  );
+}
+
+// rest of file unchanged, copied from upstream
+
+// If we navigate to a category and it becomes active, it should automatically  
+// expand itself
+function useAutoExpandActiveCategory({
+  isActive,
+  collapsed,
+  updateCollapsed,
+  activePath,
+}: {
+  isActive: boolean;
+  collapsed: boolean;
+  updateCollapsed: (b: boolean) => void;
+  activePath: string;
+}) {
+  const wasActive = usePrevious(isActive);
+  const previousActivePath = usePrevious(activePath);
+  useEffect(() => {
+    const justBecameActive = isActive && !wasActive;
+    const stillActiveButPathChanged =
+      isActive && wasActive && activePath !== previousActivePath;
+    if ((justBecameActive || stillActiveButPathChanged) && collapsed) {
+      updateCollapsed(false);
+    }
+  }, [
+    isActive,
+    wasActive,
+    collapsed,
+    updateCollapsed,
+    activePath,
+    previousActivePath,
+  ]);
+}
+
+/**
+ * When a collapsible category has no link, we still link it to its first child 
+ * during SSR as a temporary fallback. This allows to be able to navigate inside
+ * the category even when JS fails to load, is delayed or simply disabled        
+ * React hydration becomes an optional progressive enhancement
+ * see https://github.com/facebookincubator/infima/issues/36#issuecomment-772543
+ * see https://github.com/facebook/docusaurus/issues/3030
+ */
+function useCategoryHrefWithSSRFallback(
+  item: Props['item'],
+): string | undefined {
+  const isBrowser = useIsBrowser();
+  return useMemo(() => {
+    if (item.href && !item.linkUnlisted) {
+      return item.href;
+    }
+    // In these cases, it's not necessary to render a fallback
+    // We skip the "findFirstCategoryLink" computation
+    if (isBrowser || !item.collapsible) {
+      return undefined;
+    }
+    return findFirstSidebarItemLink(item);
+  }, [item, isBrowser]);
+}
+
+function CollapseButton({
+  collapsed,
+  categoryLabel,
+  onClick,
+}: {
+  collapsed: boolean;
+  categoryLabel: string;
+  onClick: ComponentProps<'button'>['onClick'];
+}) {
+  return (
+    <button
+      aria-label={
+        collapsed
+          ? translate(
+              {
+                id: 'theme.DocSidebarItem.expandCategoryAriaLabel',
+                message: "Expand sidebar category '{label}'",
+                description: 'The ARIA label to expand the sidebar category',   
+              },
+              {label: categoryLabel},
+            )
+          : translate(
+              {
+                id: 'theme.DocSidebarItem.collapseCategoryAriaLabel',
+                message: "Collapse sidebar category '{label}'",
+                description: 'The ARIA label to collapse the sidebar category', 
+              },
+              {label: categoryLabel},
+            )
+      }
+      aria-expanded={!collapsed}
+      type="button"
+      className="clean-btn menu__caret"
+      onClick={onClick}
+    >
+      {/* SVG chevron; right when collapsed, down when expanded */}
+      <svg
+        className={styles.caretIcon}
+        aria-hidden="true"
+        viewBox="0 0 8 8"
+        width="8"
+        height="8">
+        {collapsed ? (
+          <path
+            d="M2 1l4 3-4 3"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="0.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ) : (
+          <path
+            d="M1 2l3 4 3-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="0.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
+      </svg>
+    </button>
+  );
+}
+
+export default function DocSidebarItemCategory(props: Props): ReactNode {
+  const visibleChildren = useVisibleSidebarItems(
+    props.item.items,
+    props.activePath,
+  );
+  if (visibleChildren.length === 0) {
+    return <DocSidebarItemCategoryEmpty {...props} />;
+  } else {
+    return <DocSidebarItemCategoryCollapsible {...props} />;
+  }
+}
+
+function isCategoryWithHref(
+  category: PropSidebarItemCategory,
+): category is PropSidebarItemCategory & {href: string} {
+  return typeof category.href === 'string';
+}
+
+// If a category doesn't have any visible children, we render it as a link      
+function DocSidebarItemCategoryEmpty({item, ...props}: Props): ReactNode {      
+  // If the category has no link, we don't render anything
+  // It's not super useful to render a category you can't open nor click        
+  if (!isCategoryWithHref(item)) {
+    return null;
+  }
+  // We remove props that don't make sense for a link and forward the rest      
+  const {
+    type,
+    collapsed,
+    collapsible,
+    items,
+    linkUnlisted,
+    ...forwardableProps
+  } = item;
+  const linkItem: PropSidebarItemLink = {
+    type: 'link',
+    ...forwardableProps,
+  };
+  return <DocSidebarItemLink item={linkItem} {...props} />;
+}
+
+function DocSidebarItemCategoryCollapsible({
+  item,
+  onItemClick,
+  activePath,
+  level,
+  index,
+  ...props
+}: Props): ReactNode {
+  const {items, label, collapsible, className, href} = item;
+  const {
+    docs: {
+      sidebar: {autoCollapseCategories},
+    },
+  } = useThemeConfig();
+  const hrefWithSSRFallback = useCategoryHrefWithSSRFallback(item);
+  const isActive = isActiveSidebarItem(item, activePath);
+  const {
+    collapsed,
+    toggleCollapsed,
+    setCollapsed: setCollapsedRaw,
+  } = useCollapsible({
+    initialState: () =>
+      !item.collapsible ||
+      (item.collapsible && item.collapsed) ||
+      (isActive && !autoCollapseCategories),
+  });
+  const setCollapsed = (value: boolean) => {
+    // categories are never collapsed when they are active (clicked on)
+    if (!value && isActive) {
+      return;
+    }
+
+    setCollapsedRaw(value);
+    if (onItemClick) {
+      onItemClick(item);
+    }
+  };
+  useAutoExpandActiveCategory({
+    isActive,
+    collapsed,
+    updateCollapsed: setCollapsed,
+    activePath,
+  });
+
+  // expanded state across all sidebar items (used for auto-collapsing)
+  const {expandedItem, setExpandedItem} = useDocSidebarItemsExpandedState();
+  // Use this instead of `setCollapsed`, because it is also reactive
+  const updateCollapsed = (toCollapsed: boolean = !collapsed) => {
+    setExpandedItem(toCollapsed ? null : index);
+    setCollapsed(toCollapsed);
+  };
+
+  const itemsProps = {
+    ...props,
+    level: level + 1,
+    activePath,
+    onItemClick,
+    index,
+  };
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemCategory,
+        ThemeClassNames.docs.docSidebarItemCategoryLevel(level),
+        'menu__list-item',
+        className,
+      )}
+      key={label}>
+      <div
+        className={clsx(styles.categoryLink, {
+          [styles.categoryLinkWithHref]: hrefWithSSRFallback,
+        })}>
+        {hrefWithSSRFallback ? (
+          <Link
+            className={clsx('menu__link', {
+              'menu__link--active': isActive,
+              'menu__link--sublist': true,
+            })}
+            to={hrefWithSSRFallback}
+            {...(href && isInternalUrl(href) && {
+              onClick: onItemClick ? () => onItemClick(item) : undefined,
+            })}>
+            <CategoryLinkLabel label={label} />
+          </Link>
+        ) : (
+          <span
+            className={clsx('menu__link', 'menu__link--sublist', {
+              'menu__link--active': isActive,
+            })}>
+            <CategoryLinkLabel label={label} />
+          </span>
+        )}
+        {collapsible && (
+          <CollapseButton
+            collapsed={collapsed}
+            categoryLabel={label}
+            onClick={toggleCollapsed}
+          />
+        )}
+      </div>
+      {collapsible ? (
+        <Collapsible lazy as="ul" className="menu__list" collapsed={collapsed}>
+          <DocSidebarItems items={items} {...itemsProps} />
+        </Collapsible>
+      ) : (
+        <DocSidebarItems items={items} {...itemsProps} />
+      )}
+    </li>
+  );
+}

--- a/website/src/theme/DocSidebarItem/Category/styles.module.css
+++ b/website/src/theme/DocSidebarItem/Category/styles.module.css
@@ -1,0 +1,39 @@
+/**
+ * Styles for the swizzled category item.  We're reducing the label to a
+ * single line with ellipsis so that long category names don't force wrapped
+ * items and break the sidebar on narrow viewports.
+ */
+
+.categoryLink {
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+}
+
+/* never let the toggle button shrink to zero width */
+.categoryLink > button {
+  flex-shrink: 0;
+}
+
+.categoryLinkLabel {
+  flex: 1 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* preserve existing behaviour for submenu caret */
+:global(.menu__link--sublist-caret)::after {
+  margin-left: var(--ifm-menu-link-padding-vertical);
+}
+
+/* explicit icon inside collapse button */
+.caretIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  color: var(--ifm-color-menu-link); /* match normal menu text */
+  flex-shrink: 0;
+}

--- a/website/src/theme/DocSidebarItem/Link/index.tsx
+++ b/website/src/theme/DocSidebarItem/Link/index.tsx
@@ -1,0 +1,84 @@
+/**
+ * Swizzled from @docusaurus/theme-classic to add automatic truncation and
+ * a tooltip on long sidebar link labels. The default component allowed
+ * two-line wrapping which broke the layout on narrow screens.
+ *
+ * Docusaurus swizzle command that generated the original file:
+ *   npx docusaurus swizzle @docusaurus/theme-classic DocSidebarItem -- --danger
+ *
+ * We only changed the label rendering and CSS.  Keep the original logic
+ * otherwise so upgrades stay easy.
+ */
+
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {isActiveSidebarItem} from '@docusaurus/plugin-content-docs/client';
+import Link from '@docusaurus/Link';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import IconExternalLink from '@theme/Icon/ExternalLink';
+import type {Props} from '@theme/DocSidebarItem/Link';
+
+import styles from './styles.module.css';
+
+// maximum characters we want to display before truncating
+const MAX_LABEL_LENGTH = 35;
+
+function truncateText(label: string) {
+  if (label.length <= MAX_LABEL_LENGTH) {
+    return label;
+  }
+  return label.substring(0, MAX_LABEL_LENGTH - 3) + '...';
+}
+
+function LinkLabel({label}: {label: string}) {
+  const display = truncateText(label);
+  // keep the title attribute so the full text is available on hover
+  return (
+    <span title={label} className={styles.linkLabel}>
+      {display}
+    </span>
+  );
+}
+
+export default function DocSidebarItemLink({
+  item,
+  onItemClick,
+  activePath,
+  level,
+  index,
+  ...props
+}: Props): ReactNode {
+  const {href, label, className, autoAddBaseUrl} = item;
+  const isActive = isActiveSidebarItem(item, activePath);
+  const isInternalLink = isInternalUrl(href);
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemLink,
+        ThemeClassNames.docs.docSidebarItemLinkLevel(level),
+        'menu__list-item',
+        className,
+      )}
+      key={label}>
+      <Link
+        className={clsx(
+          'menu__link',
+          !isInternalLink && styles.menuExternalLink,
+          {
+            'menu__link--active': isActive,
+          },
+        )}
+        autoAddBaseUrl={autoAddBaseUrl}
+        aria-current={isActive ? 'page' : undefined}
+        to={href}
+        {...(isInternalLink && {
+          onClick: onItemClick ? () => onItemClick(item) : undefined,
+        })}
+        {...props}>
+        <LinkLabel label={label} />
+        {!isInternalLink && <IconExternalLink />}
+      </Link>
+    </li>
+  );
+}

--- a/website/src/theme/DocSidebarItem/Link/styles.module.css
+++ b/website/src/theme/DocSidebarItem/Link/styles.module.css
@@ -1,0 +1,17 @@
+/**
+ * Custom styles for the swizzled sidebar link label.  The original theme
+ * allowed a two‑line clamp which caused the long text to wrap on narrow
+ * screens. The truncated component above ensures we always render a single
+ * line, but we also add the usual ellipsis overflow CSS just in case.
+ */
+
+.menuExternalLink {
+  align-items: center;
+}
+
+.linkLabel {
+  overflow: hidden;
+  display: inline-block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION


#### **Description**

In this PR we worked on implementing best navigation experience for users reading documentation.
avigation menus contained long text entries that took up excessive space and negatively impacted readability and user experience. Overly long section titles or menu items madenavigation less clear and could cause layout issues, especially on smaller screens.

- We implemented a new component to auto-resize labels beyond 35 Characters but wrapping in a tooltip.
- Normally render short labels
- Fix icon visibility on expanded/collapsed menus

#### **Related Issue**

 `This PR is related to #155`

### **Illustration**
<img width="292" height="500" alt="Screenshot 2026-03-11 111208" src="https://github.com/user-attachments/assets/05a02fc6-2b4a-4746-b734-28d38672ac1c" />
<img width="866" height="561" alt="Screenshot 2026-03-11 113126" src="https://github.com/user-attachments/assets/105bf138-c478-4616-b2d5-232c87c279c7" />


