### PR TITLE
Docs/cardano developer contribution pathways pathway

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -20,11 +20,16 @@ Start with our comprehensive ecosystem overview: [**Directive: Kickoff & Orienta
 
 This guide provides a complete map of the Cardano ecosystem, including core repositories, documentation resources, developer tools, and community support channels.
 
-### 3. **Ready to Build?**
-Dive into our hands-on [**Beginner Guides**](./how-to-guide/beginner/) to start building immediately:
-- Understanding Cardano addresses
-- Creating transactions
-- Working with native tokens
+### 3. **Choose Your Track**
+
+Pick the path that matches your background and goals — these are parallel tracks, not sequential stages:
+
+| Track | Starting point | Guide |
+|---|---|---|
+| **dApp / Smart Contracts** | New to Cardano, building products | [Beginner Guides](./how-to-guide/beginner/) |
+| **Infrastructure / DevOps** | Running nodes, indexers, block explorers | [Advanced Guides](./how-to-guide/advanced/) |
+| **Core Protocol (Haskell)** | Systems/PL background, want to contribute to ledger or consensus | [Core Protocol Contributor](./how-to-guide/advanced/core-protocol-contributor.md) |
+| **Core Protocol (Rust)** | Rust background, want to contribute to Pallas or Dolos | [Core Protocol Contributor](./how-to-guide/advanced/core-protocol-contributor.md) |
 
 ### 4. **Want to Contribute?**
 Join our [**Developer Experience Working Group**](./working-group/sessions/q4-2025/index.md) - a quarterly initiative focused on onboarding new developers and improving the overall developer experience.

--- a/website/docs/how-to-guide/advanced/README.md
+++ b/website/docs/how-to-guide/advanced/README.md
@@ -7,19 +7,23 @@ Welcome to the Advanced Guides section! These guides are for experienced develop
 - **Cardano API**: Check out this awesome guide to Cardano API [here](./cardano-api.md)
 - **Yaci DevKit**: Setup a local Cardano devnet step by step [here](./yaci-devkit.mdx)
 
+### Core Protocol Contribution
+- **[Core Protocol Contributor Guide](./core-protocol-contributor.md)** — For Haskell and Rust developers who want to contribute to `cardano-ledger`, `ouroboros-consensus`, Pallas, or Dolos. Covers the Nix development environment, formal specifications, testing as an entry point, the CIP process, and realistic time estimates.
 
 ## Getting Involved
 
-- **Core Development**: Contribute to [IntersectMBO repositories](https://github.com/IntersectMBO)
-- **Research**: Engage with [IOG Research](https://iohk.io/en/research/library/)
+- **Core Development**: See the [Core Protocol Contributor Guide](./core-protocol-contributor.md) for how to get started with `cardano-ledger`, `ouroboros-consensus`, and Rust alternatives
+- **Research**: Engage with [IOG Research](https://iohk.io/en/research/library/) and the [Ouroboros paper series](https://iohk.io/en/research/library/)
+- **CIP Authoring**: Contribute a [Cardano Improvement Proposal](https://github.com/cardano-foundation/CIPs) — see the core contributor guide for how the process works
 - **Community Leadership**: Lead [Working Group sessions](../../working-group/readme.md)
 - **Mentorship**: Help in Discord and Stack Exchange
 
 ## Resources for Advanced Developers
 
-- [Cardano Improvement Proposals (CIPs)](https://github.com/cardano-foundation/CIPs)
-- [Formal Specifications](https://github.com/IntersectMBO/cardano-ledger#formal-specifications)
-- [Technical Working Groups](https://intersectmbo.org)
+- [Cardano Improvement Proposals (CIPs)](https://github.com/cardano-foundation/CIPs) — protocol-level changes go through here, not PRs
+- [Cardano Ledger Formal Specifications](https://github.com/IntersectMBO/cardano-ledger/releases) — the ground truth for correct ledger behaviour; the Haskell implementation must match these
+- [Ouroboros Research Papers](https://iohk.io/en/research/library/) — the academic foundation for consensus
+- [Technical Working Groups](https://intersectmbo.org) — shape protocol direction before writing a line of code
 
 ---
 

--- a/website/docs/how-to-guide/advanced/README.md
+++ b/website/docs/how-to-guide/advanced/README.md
@@ -8,7 +8,10 @@ Welcome to the Advanced Guides section! These guides are for experienced develop
 - **Yaci DevKit**: Setup a local Cardano devnet step by step [here](./yaci-devkit.mdx)
 
 ### Core Protocol Contribution
-- **[Core Protocol Contributor Guide](./core-protocol-contributor.md)** — For Haskell and Rust developers who want to contribute to `cardano-ledger`, `ouroboros-consensus`, Pallas, or Dolos. Covers the Nix development environment, formal specifications, testing as an entry point, the CIP process, and realistic time estimates.
+- **[Core Protocol Contributor](./core-protocol-contributor.md)** — Overview and language path selector
+  - **[Haskell](./haskell-core-contributor.md)** — `cardano-ledger`, `ouroboros-consensus`, `cardano-node`. Covers Nix setup, formal specs, STS framework, CIP process, and time estimates
+  - **[Rust](./rust-core-contributor.md)** — Amaru (full node), Pallas (primitives), Dolos (data node). Covers `cargo`-based setup, Pallas progression, Amaru deep dive
+  - **[Go](./go-core-contributor.md)** — Dingo (full node by Blink Labs), gouroboros (Ouroboros networking). Lowest barrier to first contribution; unique API layer entry points
 
 ## Getting Involved
 

--- a/website/docs/how-to-guide/advanced/core-protocol-contributor.md
+++ b/website/docs/how-to-guide/advanced/core-protocol-contributor.md
@@ -1,0 +1,214 @@
+---
+sidebar_position: 4
+title: Core Protocol Contributor
+---
+
+# Becoming a Core Protocol Contributor
+
+This guide is for systems engineers, compiler writers, protocol researchers, formal methods practitioners, and Haskell or Rust developers who want to contribute to the **core of Cardano** — not just build applications on top of it.
+
+This is a **parallel track**, not a destination you reach after shipping a dApp. If your background is in programming languages, distributed systems, cryptography, or formal verification, this is your entry point.
+
+
+## The Two Main Paths
+
+### Path A — Haskell: Ledger & Consensus
+
+The core of Cardano is implemented in Haskell across several tightly coupled repositories. Start with `cardano-ledger` for ledger rules or `ouroboros-consensus` for chain selection and block validation — these are the two deepest entry points.
+
+| Repository | What it governs | Where to start |
+|---|---|---|
+| [`cardano-ledger`](https://github.com/IntersectMBO/cardano-ledger) | All ledger rules — how transactions are validated, how state transitions work using the STS framework | [Good first issues](https://github.com/IntersectMBO/cardano-ledger/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+| [`ouroboros-consensus`](https://github.com/IntersectMBO/ouroboros-consensus) | The Ouroboros consensus algorithm, chain selection, and block validation | [Good first issues](https://github.com/IntersectMBO/ouroboros-consensus/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+| [`ouroboros-network`](https://github.com/IntersectMBO/ouroboros-network) | The peer-to-peer networking layer — mini-protocols, connection management | [Issues](https://github.com/IntersectMBO/ouroboros-network/issues) |
+| [`cardano-node`](https://github.com/IntersectMBO/cardano-node) | The node executable that ties ledger, consensus, and networking together | [Issues](https://github.com/IntersectMBO/cardano-node/issues) |
+| [`cardano-api`](https://github.com/IntersectMBO/cardano-api) | High-level Haskell library over ledger/consensus; the interface used by CLI and tooling | [Good first issues](https://github.com/IntersectMBO/cardano-api/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+| [`cardano-cli`](https://github.com/IntersectMBO/cardano-cli) | The official command-line interface — good for contributor-friendly Haskell issues | [Good first issues](https://github.com/IntersectMBO/cardano-cli/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+| [`cardano-base`](https://github.com/IntersectMBO/cardano-base) | Shared cryptography, slotting, and binary serialization libraries used across the stack | [Issues](https://github.com/IntersectMBO/cardano-base/issues) |
+| [`plutus`](https://github.com/IntersectMBO/plutus) | The Plutus Core language and execution engine — compiler, evaluator, cost models | [Good first issues](https://github.com/IntersectMBO/plutus/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+
+
+
+Before navigating any of these repos, read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html) — it is the clearest available explanation of how the node, ledger, and consensus layers fit together, written without assuming you already know the codebase.
+
+For a full list of core IntersectMBO repositories, see the [Essential Repositories](../../resources/repositories.md) page.
+
+### Path B — Rust: Protocol Libraries & Alternative Node Implementations
+
+The Rust ecosystem offers a more accessible entry point than the Haskell path: standard `cargo` toolchain (no Nix required for most projects), faster review cycles, and well-labelled first issues. The key decision is which layer of the stack you want to work on.
+
+**Choose your focus:**
+
+| Goal | Start here |
+|---|---|
+| Understand and implement protocol primitives (CBOR encoding, mini-protocols, crypto types) | [Pallas](https://github.com/txpipe/pallas) |
+| Build or contribute to a full Rust Cardano node | [Amaru](https://github.com/pragma-org/amaru) |
+| Work on chain data access and indexing at the node level | [Dolos](https://github.com/txpipe/dolos) |
+| Build event streaming pipelines from the chain | [Oura](https://github.com/txpipe/oura) |
+| Off-chain transaction building in Rust | [Whisky](https://github.com/sidan-lab/whisky) |
+
+**The dependency between these projects:**
+
+```
+Pallas (protocol primitives)
+  ├── Dolos (data node built on Pallas)
+  ├── Amaru (full node — uses Pallas primitives)
+  └── Oura (event pipeline built on Pallas)
+```
+
+Start with Pallas if you are new to the Cardano protocol. Its primitives crate is the shared foundation: once you understand CBOR encoding, the UTxO model in Rust types, and the mini-protocol framing, contributing to Amaru or Dolos becomes significantly easier.
+
+**Progression for Pallas:**
+
+1. Clone the repo and run `cargo build` — it just works, no special setup
+2. Read the [`pallas-primitives`](https://github.com/txpipe/pallas/tree/main/pallas-primitives) crate — this is the Cardano data model in Rust
+3. Read the [`pallas-network`](https://github.com/txpipe/pallas/tree/main/pallas-network) crate — the mini-protocol implementation
+4. Find a [good first issue](https://github.com/txpipe/pallas/issues?q=is%3Aopen+label%3A%22good+first+issue%22) in the codec, network, or traverse modules
+5. Open a PR — review cycles are typically days, not weeks
+
+**Progression for Amaru (the deeper path):**
+
+1. Read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html) — the implementation-independent guide to how the protocol works; essential before reading Amaru's code
+2. Read the [Amaru architecture docs](https://github.com/pragma-org/amaru) in the repo — understand how it decomposes the node into ledger, consensus, and network stages
+3. Read the relevant formal spec section for the area you want to contribute to (ledger rules → Shelley/Conway spec; consensus → Ouroboros Praos paper — same specs as the Haskell path, same ground truth)
+4. Get Pallas familiarity first — Amaru builds on Pallas types extensively
+5. Find a [good first issue](https://github.com/pragma-org/amaru/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — ledger rule implementations and test coverage are the most accessible areas
+6. Conformance testing between Amaru and the Haskell node is high-value work that requires understanding the formal specs but not Haskell fluency — this is a strong first contribution area
+
+> **Important**: Amaru implements the same formal specifications as the Haskell node. Any work on Amaru's ledger or consensus logic requires reading the same specs listed in the [Formal Specifications](#the-formal-specifications) section below — the Rust path does not skip that step.
+
+
+## Step 0: The Dependency Wall (Read This First)
+
+Every core Cardano repository — `cardano-node`, `cardano-ledger`, `ouroboros-consensus`, `cardano-api`, Pallas, Dolos — has a complex dependency graph involving GHC version constraints, C library dependencies, cryptographic primitives, and cross-platform linker flags.
+
+**Attempting to resolve this manually will fail.** Depending on your OS and distribution, it ranges from painful to impossible. On NixOS specifically, non-Nix builds do not work by design.
+
+**[Nix](https://nixos.org/download) is the standard working environment for contributors to these projects.** A `nix develop` invocation drops you into an environment where all dependencies are pinned, present, and working.
+
+Getting started with Nix:
+- [`nix-installer` by Determinate Systems](https://github.com/DeterminateSystems/nix-installer) — the recommended installer
+- [`devenv`](https://devenv.sh/) — a developer-friendly layer on top of Nix
+- Each repo's `flake.nix` or `shell.nix` defines the development shell — run `nix develop` from the repo root
+
+This is not an arbitrary requirement. Nix is what makes an otherwise intractable dependency problem manageable for everyone on the same codebase.
+
+
+## Reading Before You Code: The Cardano Blueprint
+
+Before diving into any repository — Haskell or Rust — read the **[Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html)**.
+
+The Blueprint is implementation-independent documentation that explains how the Cardano protocol actually works: written in accessible Markdown with diagrams and test data, not dense academic LaTeX. It is maintained by the community specifically to help node developers and contributors understand the protocol without needing to reverse-engineer it from the Haskell source. It covers the node architecture, the ledger state machine, consensus mechanics, and the networking layer — the same territory you will encounter in both `cardano-ledger`/`ouroboros-consensus` and in Amaru/Pallas.
+
+Read this first. It will make every other document and codebase significantly easier to navigate.
+
+## The Formal Specifications
+
+The formal specifications define **what correct behavior looks like** at the mathematical level. Both the Haskell node and Amaru must match them. Once you have the Blueprint as context, these become readable.
+
+| Document | What it specifies |
+|---|---|
+| [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html) | Implementation-independent protocol guide — start here before the specs below |
+| [Shelley Ledger Formal Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | The foundational ledger rules using small-step semantics (STS) |
+| [Conway Ledger Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | CIP-1694 governance, DRep ratification, committee logic |
+| [Ouroboros papers](https://iohk.io/en/research/library/) | The family of consensus protocol proofs (Classic, BFT, Praos, Genesis) |
+
+The STS (small-step semantics) framework that governs all ledger rules is the conceptual backbone of `cardano-ledger`. Understanding it is the difference between reading the code and understanding it.
+
+
+## Your Most Accessible Entry Point: Testing
+
+You do not need to implement a new ledger rule to make a valuable core contribution. **Writing tests is often where new contributors start**, and it is high-value work.
+
+`cardano-ledger` has substantial test infrastructure built on property-based testing:
+
+- **[Hedgehog](https://github.com/hedgehogqa/haskell-hedgehog)** and **[QuickCheck](https://github.com/nick8325/quickcheck)** are used throughout
+- **Conformance testing** — verifying that alternative implementations (Rust, etc.) match the Haskell ledger rules — is an ongoing effort and a legitimate core contribution
+- The test suite documents expected behavior; writing a test for an existing rule is a concrete, reviewable contribution
+
+**Good first issues in the testing area:**
+- Search for `good first issue` or `testing` labels in [`cardano-ledger` issues](https://github.com/IntersectMBO/cardano-ledger/issues)
+- Look at existing `Spec` modules in `cardano-ledger` to understand the testing patterns
+
+
+## How to Contribute a CIP
+
+A Cardano Improvement Proposal (CIP) is how many core contributions happen — especially changes to ledger rules, protocol parameters, or cryptographic primitives. This is a distinct process, not just a GitHub PR.
+
+**What becomes a CIP vs. a PR:**
+- Changes that affect the protocol specification → CIP
+- Bug fixes, test additions, or implementation details that don't change the spec → normal PR/issue
+
+**The CIP stages:**
+
+1. **Proposed** — draft submitted to the [CIPs repository](https://github.com/cardano-foundation/CIPs) as a PR
+2. **Candidate** — reviewed and accepted by CIP editors, open for community comment
+3. **Active** — ratified and incorporated into a hard fork or ecosystem tooling
+
+**Key contacts and venues:**
+- CIP editors review submissions in the CIPs repo PRs
+- Intersect's Technical Steering Committee (TSC) working groups often discuss CIPs in progress — see [Intersect Working Groups](../../working-group/sessions/q1-2026/07-contributing-intersect/session-notes/readme.md) for how to find and join them
+- The `#cip-discussion` channel in the [Cardano Discord](https://discord.gg/cardano) is the informal venue for early feedback
+
+The [CIPs repository `README`](https://github.com/cardano-foundation/CIPs/blob/master/README.md) has the authoritative process document, but it assumes ecosystem familiarity. Reading a few merged CIPs (CIP-1694, CIP-0381) before writing your own will calibrate your expectations on scope and depth.
+
+
+## Governance Protocol Work (Not DRep Participation)
+
+Governance in Cardano operates at three distinct layers — **don't conflate them**:
+
+| Layer | What it is | Example work |
+|---|---|---|
+| **Governance participation** | Being a DRep, voting, joining Intersect | Register as a DRep, join a working group |
+| **Governance tooling** | Application development on governance infrastructure | GovTool, Agora, wallet integrations for voting |
+| **Governance protocol** | Core ledger rules governing governance itself | CIP-1694 implementation in `cardano-ledger`, Conway era ledger rules, DRep pulsing, ratification logic, committee expiry |
+
+The third layer is core protocol work. Someone contributing to the Conway era ledger rules has a completely different profile from someone using GovTool to vote. The Conway era modules in `cardano-ledger` are a good starting point:
+- [`Cardano.Ledger.Conway.Rules`](https://github.com/IntersectMBO/cardano-ledger/tree/master/eras/conway/impl/src/Cardano/Ledger/Conway/Rules) — the STS rules for governance
+- The Conway formal spec (linked in Formal Specifications above)
+
+For governance **participation and tooling**, see the [Intersect Membership Guide](../../intersect-membership-guide.md).
+
+
+## Realistic Time Estimates
+
+Be honest with yourself about the investment required. This is a longer path than dApp development.
+
+| Milestone | Realistic timeframe |
+|---|---|
+| Nix environment working, repo builds locally | 1–3 days |
+| Read the relevant formal spec section for your target area | 1–2 weeks |
+| Understand the STS rule framework in `cardano-ledger` | 2–4 weeks |
+| Navigate the module structure of `cardano-ledger` or `ouroboros-consensus` | 2–4 weeks |
+| Write a meaningful test for an existing rule | 1–2 months from starting |
+| First non-trivial PR merged to `cardano-ledger` | 6–12 months from starting (from general Haskell competence) |
+| First PR to `ouroboros-consensus` | 9–18 months (requires deeper Haskell and academic background) |
+| Pallas first PR (Rust path) | 2–6 weeks (most accessible entry point) |
+| Amaru first PR (Rust node) | 4–8 weeks — read the formal spec section for your target area first |
+| Meaningful Amaru contribution (consensus or ledger rules) | 3–6 months from a Rust systems background |
+
+The review team for core Haskell repositories is small and specialized. Rust projects like Pallas and Amaru tend to have faster review cycles and more contributor-friendly onboarding. Factor this into your expectations.
+
+
+## Getting Involved with Intersect Working Groups
+
+Core protocol work doesn't require Haskell fluency to participate in early stages. Intersect's working groups directly shape which CIPs get prioritized and which protocol changes get funded.
+
+**Relevant working groups:**
+- **Technical Steering Committee (TSC)** — Consensus, DB Sync, Network Evolution, Layer 2
+- **Open Source Committee (OSC)** — developer experience, tooling, open-source standards
+
+See [Contributing to Intersect](../../working-group/sessions/q1-2026/07-contributing-intersect/session-notes/readme.md) for how to find and join working groups. Membership is required to access Discord channels — see the [Intersect Membership Guide](../../intersect-membership-guide.md).
+
+
+
+## Summary: Five Highest-Impact First Steps
+
+1. **Read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html)** — the implementation-independent protocol guide; the right starting point for both Haskell and Rust paths
+2. **Set up your environment** — Haskell: install Nix and run `nix develop` in a core repo; Rust: clone Pallas and run `cargo build`
+3. **Read the formal spec** for your target area — ledger rules: Shelley/Conway spec; consensus: Ouroboros Praos paper
+4. **Write a test** for an existing rule — in `cardano-ledger` search for `good first issue` testing labels; in Amaru look for conformance test gaps
+5. **Join a TSC working group** — you can contribute to protocol direction before your first PR, regardless of which language path you are on
+
+
+*For contributing to this repository's documentation, see the [Contributing Guidelines](https://github.com/IntersectMBO/developer-experience/blob/main/CONTRIBUTING.md). For joining Intersect as a member, see the [Intersect Membership Guide](../../intersect-membership-guide.md).*

--- a/website/docs/how-to-guide/advanced/core-protocol-contributor.md
+++ b/website/docs/how-to-guide/advanced/core-protocol-contributor.md
@@ -5,210 +5,41 @@ title: Core Protocol Contributor
 
 # Becoming a Core Protocol Contributor
 
-This guide is for systems engineers, compiler writers, protocol researchers, formal methods practitioners, and Haskell or Rust developers who want to contribute to the **core of Cardano** — not just build applications on top of it.
+This section is for systems engineers, compiler writers, protocol researchers, formal methods practitioners, and developers who want to contribute to the **core of Cardano**: not build applications on top of it.
 
 This is a **parallel track**, not a destination you reach after shipping a dApp. If your background is in programming languages, distributed systems, cryptography, or formal verification, this is your entry point.
 
+## Start Here: The Cardano Blueprint
 
-## The Two Main Paths
+Before choosing a language path, read the **[Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html)**.
 
-### Path A — Haskell: Ledger & Consensus
+The Blueprint is implementation-independent documentation explaining how the Cardano protocol works: node architecture, ledger state machine, consensus mechanics, and networking: written in accessible Markdown with diagrams and test data, not dense academic LaTeX. It applies equally to every language path below. Reading it first will make every codebase significantly easier to navigate.
 
-The core of Cardano is implemented in Haskell across several tightly coupled repositories. Start with `cardano-ledger` for ledger rules or `ouroboros-consensus` for chain selection and block validation — these are the two deepest entry points.
+## Choose Your Path
 
-| Repository | What it governs | Where to start |
-|---|---|---|
-| [`cardano-ledger`](https://github.com/IntersectMBO/cardano-ledger) | All ledger rules — how transactions are validated, how state transitions work using the STS framework | [Good first issues](https://github.com/IntersectMBO/cardano-ledger/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
-| [`ouroboros-consensus`](https://github.com/IntersectMBO/ouroboros-consensus) | The Ouroboros consensus algorithm, chain selection, and block validation | [Good first issues](https://github.com/IntersectMBO/ouroboros-consensus/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
-| [`ouroboros-network`](https://github.com/IntersectMBO/ouroboros-network) | The peer-to-peer networking layer — mini-protocols, connection management | [Issues](https://github.com/IntersectMBO/ouroboros-network/issues) |
-| [`cardano-node`](https://github.com/IntersectMBO/cardano-node) | The node executable that ties ledger, consensus, and networking together | [Issues](https://github.com/IntersectMBO/cardano-node/issues) |
-| [`cardano-api`](https://github.com/IntersectMBO/cardano-api) | High-level Haskell library over ledger/consensus; the interface used by CLI and tooling | [Good first issues](https://github.com/IntersectMBO/cardano-api/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
-| [`cardano-cli`](https://github.com/IntersectMBO/cardano-cli) | The official command-line interface — good for contributor-friendly Haskell issues | [Good first issues](https://github.com/IntersectMBO/cardano-cli/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
-| [`cardano-base`](https://github.com/IntersectMBO/cardano-base) | Shared cryptography, slotting, and binary serialization libraries used across the stack | [Issues](https://github.com/IntersectMBO/cardano-base/issues) |
-| [`plutus`](https://github.com/IntersectMBO/plutus) | The Plutus Core language and execution engine — compiler, evaluator, cost models | [Good first issues](https://github.com/IntersectMBO/plutus/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+| Language | Node / Project | Stage | Guide |
+|---|---|---|---|
+| **Haskell** | `cardano-node`: the reference implementation | Production | [Haskell Core Contributor](./haskell-core-contributor.md) |
+| **Rust** | Amaru (Pragma), Pallas / Dolos (TxPipe) | Active development | [Rust Core Contributor](./rust-core-contributor.md) |
+| **Go** | Dingo (Blink Labs) | Testnet / active development | [Go Core Contributor](./go-core-contributor.md) |
 
+None of these paths requires the others as a prerequisite. Choose based on your background and the kind of work you want to do.
 
+## Shared Resources
 
-Before navigating any of these repos, read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html) — it is the clearest available explanation of how the node, ledger, and consensus layers fit together, written without assuming you already know the codebase.
+These apply to all three paths:
 
-For a full list of core IntersectMBO repositories, see the [Essential Repositories](../../resources/repositories.md) page.
+- **[Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html)**: start here
+- **[Shelley Ledger Formal Spec](https://github.com/IntersectMBO/cardano-ledger/releases)**: the foundational ledger rules
+- **[Conway Ledger Spec](https://github.com/IntersectMBO/cardano-ledger/releases)**: CIP-1694 governance, Conway era rules
+- **[Ouroboros papers](https://iohk.io/en/research/library/)**: the consensus protocol proofs
+- **[CIPs repository](https://github.com/cardano-foundation/CIPs)**: where protocol-level changes are proposed
+- **[Essential Repositories](../../resources/repositories.md)**: full list of core and community repos
 
-### Path B — Rust: Protocol Libraries & Alternative Node Implementations
+## Contributing to Protocol Direction
 
-The Rust ecosystem offers a more accessible entry point than the Haskell path: standard `cargo` toolchain (no Nix required for most projects), faster review cycles, and well-labelled first issues. The key decision is which layer of the stack you want to work on.
+Core protocol work doesn't require writing code to participate. Intersect's Technical Steering Committee (TSC) working groups shape which CIPs get prioritized and which protocol changes get funded: across all node implementations.
 
-**Choose your focus:**
+See [Contributing to Intersect](../../working-group/sessions/q1-2026/07-contributing-intersect/session-notes/readme.md) for how to find and join working groups. See the [Intersect Membership Guide](../../intersect-membership-guide.md) for membership access.
 
-| Goal | Start here |
-|---|---|
-| Understand and implement protocol primitives (CBOR encoding, mini-protocols, crypto types) | [Pallas](https://github.com/txpipe/pallas) |
-| Build or contribute to a full Rust Cardano node | [Amaru](https://github.com/pragma-org/amaru) |
-| Work on chain data access and indexing at the node level | [Dolos](https://github.com/txpipe/dolos) |
-| Build event streaming pipelines from the chain | [Oura](https://github.com/txpipe/oura) |
-| Off-chain transaction building in Rust | [Whisky](https://github.com/sidan-lab/whisky) |
-
-**The dependency between these projects:**
-
-```
-Pallas (protocol primitives)
-  ├── Dolos (data node built on Pallas)
-  ├── Amaru (full node — uses Pallas primitives)
-  └── Oura (event pipeline built on Pallas)
-```
-
-Start with Pallas if you are new to the Cardano protocol. Its primitives crate is the shared foundation: once you understand CBOR encoding, the UTxO model in Rust types, and the mini-protocol framing, contributing to Amaru or Dolos becomes significantly easier.
-
-**Progression for Pallas:**
-
-1. Clone the repo and run `cargo build` — it just works, no special setup
-2. Read the [`pallas-primitives`](https://github.com/txpipe/pallas/tree/main/pallas-primitives) crate — this is the Cardano data model in Rust
-3. Read the [`pallas-network`](https://github.com/txpipe/pallas/tree/main/pallas-network) crate — the mini-protocol implementation
-4. Find a [good first issue](https://github.com/txpipe/pallas/issues?q=is%3Aopen+label%3A%22good+first+issue%22) in the codec, network, or traverse modules
-5. Open a PR — review cycles are typically days, not weeks
-
-**Progression for Amaru (the deeper path):**
-
-1. Read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html) — the implementation-independent guide to how the protocol works; essential before reading Amaru's code
-2. Read the [Amaru architecture docs](https://github.com/pragma-org/amaru) in the repo — understand how it decomposes the node into ledger, consensus, and network stages
-3. Read the relevant formal spec section for the area you want to contribute to (ledger rules → Shelley/Conway spec; consensus → Ouroboros Praos paper — same specs as the Haskell path, same ground truth)
-4. Get Pallas familiarity first — Amaru builds on Pallas types extensively
-5. Find a [good first issue](https://github.com/pragma-org/amaru/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — ledger rule implementations and test coverage are the most accessible areas
-6. Conformance testing between Amaru and the Haskell node is high-value work that requires understanding the formal specs but not Haskell fluency — this is a strong first contribution area
-
-> **Important**: Amaru implements the same formal specifications as the Haskell node. Any work on Amaru's ledger or consensus logic requires reading the same specs listed in the [Formal Specifications](#the-formal-specifications) section below — the Rust path does not skip that step.
-
-
-## Step 0: The Dependency Wall (Read This First)
-
-Every core Cardano repository — `cardano-node`, `cardano-ledger`, `ouroboros-consensus`, `cardano-api`, Pallas, Dolos — has a complex dependency graph involving GHC version constraints, C library dependencies, cryptographic primitives, and cross-platform linker flags.
-
-**Attempting to resolve this manually will fail.** Depending on your OS and distribution, it ranges from painful to impossible. On NixOS specifically, non-Nix builds do not work by design.
-
-**[Nix](https://nixos.org/download) is the standard working environment for contributors to these projects.** A `nix develop` invocation drops you into an environment where all dependencies are pinned, present, and working.
-
-Getting started with Nix:
-- [`nix-installer` by Determinate Systems](https://github.com/DeterminateSystems/nix-installer) — the recommended installer
-- [`devenv`](https://devenv.sh/) — a developer-friendly layer on top of Nix
-- Each repo's `flake.nix` or `shell.nix` defines the development shell — run `nix develop` from the repo root
-
-This is not an arbitrary requirement. Nix is what makes an otherwise intractable dependency problem manageable for everyone on the same codebase.
-
-
-## Reading Before You Code: The Cardano Blueprint
-
-Before diving into any repository — Haskell or Rust — read the **[Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html)**.
-
-The Blueprint is implementation-independent documentation that explains how the Cardano protocol actually works: written in accessible Markdown with diagrams and test data, not dense academic LaTeX. It is maintained by the community specifically to help node developers and contributors understand the protocol without needing to reverse-engineer it from the Haskell source. It covers the node architecture, the ledger state machine, consensus mechanics, and the networking layer — the same territory you will encounter in both `cardano-ledger`/`ouroboros-consensus` and in Amaru/Pallas.
-
-Read this first. It will make every other document and codebase significantly easier to navigate.
-
-## The Formal Specifications
-
-The formal specifications define **what correct behavior looks like** at the mathematical level. Both the Haskell node and Amaru must match them. Once you have the Blueprint as context, these become readable.
-
-| Document | What it specifies |
-|---|---|
-| [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html) | Implementation-independent protocol guide — start here before the specs below |
-| [Shelley Ledger Formal Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | The foundational ledger rules using small-step semantics (STS) |
-| [Conway Ledger Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | CIP-1694 governance, DRep ratification, committee logic |
-| [Ouroboros papers](https://iohk.io/en/research/library/) | The family of consensus protocol proofs (Classic, BFT, Praos, Genesis) |
-
-The STS (small-step semantics) framework that governs all ledger rules is the conceptual backbone of `cardano-ledger`. Understanding it is the difference between reading the code and understanding it.
-
-
-## Your Most Accessible Entry Point: Testing
-
-You do not need to implement a new ledger rule to make a valuable core contribution. **Writing tests is often where new contributors start**, and it is high-value work.
-
-`cardano-ledger` has substantial test infrastructure built on property-based testing:
-
-- **[Hedgehog](https://github.com/hedgehogqa/haskell-hedgehog)** and **[QuickCheck](https://github.com/nick8325/quickcheck)** are used throughout
-- **Conformance testing** — verifying that alternative implementations (Rust, etc.) match the Haskell ledger rules — is an ongoing effort and a legitimate core contribution
-- The test suite documents expected behavior; writing a test for an existing rule is a concrete, reviewable contribution
-
-**Good first issues in the testing area:**
-- Search for `good first issue` or `testing` labels in [`cardano-ledger` issues](https://github.com/IntersectMBO/cardano-ledger/issues)
-- Look at existing `Spec` modules in `cardano-ledger` to understand the testing patterns
-
-
-## How to Contribute a CIP
-
-A Cardano Improvement Proposal (CIP) is how many core contributions happen — especially changes to ledger rules, protocol parameters, or cryptographic primitives. This is a distinct process, not just a GitHub PR.
-
-**What becomes a CIP vs. a PR:**
-- Changes that affect the protocol specification → CIP
-- Bug fixes, test additions, or implementation details that don't change the spec → normal PR/issue
-
-**The CIP stages:**
-
-1. **Proposed** — draft submitted to the [CIPs repository](https://github.com/cardano-foundation/CIPs) as a PR
-2. **Candidate** — reviewed and accepted by CIP editors, open for community comment
-3. **Active** — ratified and incorporated into a hard fork or ecosystem tooling
-
-**Key contacts and venues:**
-- CIP editors review submissions in the CIPs repo PRs
-- Intersect's Technical Steering Committee (TSC) working groups often discuss CIPs in progress — see [Intersect Working Groups](../../working-group/sessions/q1-2026/07-contributing-intersect/session-notes/readme.md) for how to find and join them
-- The `#cip-discussion` channel in the [Cardano Discord](https://discord.gg/cardano) is the informal venue for early feedback
-
-The [CIPs repository `README`](https://github.com/cardano-foundation/CIPs/blob/master/README.md) has the authoritative process document, but it assumes ecosystem familiarity. Reading a few merged CIPs (CIP-1694, CIP-0381) before writing your own will calibrate your expectations on scope and depth.
-
-
-## Governance Protocol Work (Not DRep Participation)
-
-Governance in Cardano operates at three distinct layers — **don't conflate them**:
-
-| Layer | What it is | Example work |
-|---|---|---|
-| **Governance participation** | Being a DRep, voting, joining Intersect | Register as a DRep, join a working group |
-| **Governance tooling** | Application development on governance infrastructure | GovTool, Agora, wallet integrations for voting |
-| **Governance protocol** | Core ledger rules governing governance itself | CIP-1694 implementation in `cardano-ledger`, Conway era ledger rules, DRep pulsing, ratification logic, committee expiry |
-
-The third layer is core protocol work. Someone contributing to the Conway era ledger rules has a completely different profile from someone using GovTool to vote. The Conway era modules in `cardano-ledger` are a good starting point:
-- [`Cardano.Ledger.Conway.Rules`](https://github.com/IntersectMBO/cardano-ledger/tree/master/eras/conway/impl/src/Cardano/Ledger/Conway/Rules) — the STS rules for governance
-- The Conway formal spec (linked in Formal Specifications above)
-
-For governance **participation and tooling**, see the [Intersect Membership Guide](../../intersect-membership-guide.md).
-
-
-## Realistic Time Estimates
-
-Be honest with yourself about the investment required. This is a longer path than dApp development.
-
-| Milestone | Realistic timeframe |
-|---|---|
-| Nix environment working, repo builds locally | 1–3 days |
-| Read the relevant formal spec section for your target area | 1–2 weeks |
-| Understand the STS rule framework in `cardano-ledger` | 2–4 weeks |
-| Navigate the module structure of `cardano-ledger` or `ouroboros-consensus` | 2–4 weeks |
-| Write a meaningful test for an existing rule | 1–2 months from starting |
-| First non-trivial PR merged to `cardano-ledger` | 6–12 months from starting (from general Haskell competence) |
-| First PR to `ouroboros-consensus` | 9–18 months (requires deeper Haskell and academic background) |
-| Pallas first PR (Rust path) | 2–6 weeks (most accessible entry point) |
-| Amaru first PR (Rust node) | 4–8 weeks — read the formal spec section for your target area first |
-| Meaningful Amaru contribution (consensus or ledger rules) | 3–6 months from a Rust systems background |
-
-The review team for core Haskell repositories is small and specialized. Rust projects like Pallas and Amaru tend to have faster review cycles and more contributor-friendly onboarding. Factor this into your expectations.
-
-
-## Getting Involved with Intersect Working Groups
-
-Core protocol work doesn't require Haskell fluency to participate in early stages. Intersect's working groups directly shape which CIPs get prioritized and which protocol changes get funded.
-
-**Relevant working groups:**
-- **Technical Steering Committee (TSC)** — Consensus, DB Sync, Network Evolution, Layer 2
-- **Open Source Committee (OSC)** — developer experience, tooling, open-source standards
-
-See [Contributing to Intersect](../../working-group/sessions/q1-2026/07-contributing-intersect/session-notes/readme.md) for how to find and join working groups. Membership is required to access Discord channels — see the [Intersect Membership Guide](../../intersect-membership-guide.md).
-
-
-
-## Summary: Five Highest-Impact First Steps
-
-1. **Read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html)** — the implementation-independent protocol guide; the right starting point for both Haskell and Rust paths
-2. **Set up your environment** — Haskell: install Nix and run `nix develop` in a core repo; Rust: clone Pallas and run `cargo build`
-3. **Read the formal spec** for your target area — ledger rules: Shelley/Conway spec; consensus: Ouroboros Praos paper
-4. **Write a test** for an existing rule — in `cardano-ledger` search for `good first issue` testing labels; in Amaru look for conformance test gaps
-5. **Join a TSC working group** — you can contribute to protocol direction before your first PR, regardless of which language path you are on
-
-
-*For contributing to this repository's documentation, see the [Contributing Guidelines](https://github.com/IntersectMBO/developer-experience/blob/main/CONTRIBUTING.md). For joining Intersect as a member, see the [Intersect Membership Guide](../../intersect-membership-guide.md).*
+*For contributing to this documentation site, see the [Contributing Guidelines](https://github.com/IntersectMBO/developer-experience/blob/main/CONTRIBUTING.md).*

--- a/website/docs/how-to-guide/advanced/go-core-contributor.md
+++ b/website/docs/how-to-guide/advanced/go-core-contributor.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 7
+title: Go Core Contributor
+---
+
+# Go Core Contributor
+
+This guide covers contributing to Cardano's core protocol in Go: through **Dingo** (a full Go node implementation by Blink Labs) and **gouroboros** (the underlying Go Ouroboros networking library).
+
+> **Stage**: Dingo is in active development and currently supports testnets (preview, preprod) and devnets. It is not yet production-ready for mainnet. This is a great time to contribute: the codebase is young, issues are well-labelled, and the team is actively onboarding contributors.
+
+Before reading further, make sure you have read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html). The Blueprint explains the Cardano protocol in implementation-independent terms: equally applicable to Go, Haskell, and Rust.
+
+## The Projects
+
+| Repository | What it does | Where to start |
+|---|---|---|
+| [blinklabs-io/node](https://github.com/blinklabs-io/node) | **Dingo**: full Go Cardano node: chain sync, UTxO tracking, Plutus V1/V2/V3, block production, multiple storage backends | [Good first issues](https://github.com/blinklabs-io/node/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+| [blinklabs-io/gouroboros](https://github.com/blinklabs-io/gouroboros) | Go implementation of the Ouroboros networking protocol: mini-protocols, connection multiplexing, CBOR codec | [Good first issues](https://github.com/blinklabs-io/gouroboros/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+
+**How these relate:**
+
+```
+gouroboros (Ouroboros mini-protocols in Go: the networking layer)
+  └── Dingo (full node built on gouroboros)
+```
+
+Start with `gouroboros` if you want to work on the networking and protocol layer. Start with `Dingo` directly if you want to work on ledger rules, UTxO handling, block production, or the API layer.
+
+## Environment Setup
+
+The Go path has the simplest setup of all three language paths: standard Go toolchain, no Nix required.
+
+```bash
+# Install Go (1.21+ recommended)
+# https://go.dev/dl/
+
+# Clone and build Dingo
+git clone https://github.com/blinklabs-io/node
+cd node
+go build ./...
+
+# Or clone gouroboros
+git clone https://github.com/blinklabs-io/gouroboros
+cd gouroboros
+go build ./...
+```
+
+## Progression: Starting with gouroboros
+
+1. Clone the repo and run `go build ./...`
+2. Read the `protocol/` directory: each Ouroboros mini-protocol (ChainSync, BlockFetch, TxSubmission, etc.) is implemented as a separate package
+3. Read the [Cardano Blueprint networking section](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html) to understand what each mini-protocol does before reading the Go code
+4. Find a [good first issue](https://github.com/blinklabs-io/gouroboros/issues?q=is%3Aopen+label%3A%22good+first+issue%22): protocol implementation gaps, test coverage, and codec improvements are common entry points
+5. Open a PR
+
+## Progression: Contributing to Dingo
+
+1. **Read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html)**: essential context before reading the node code
+2. **Get gouroboros familiarity**: Dingo uses it for all node-to-node communication; understanding the mini-protocol layer makes the rest of the codebase readable
+3. **Read the relevant formal spec** for the area you want to contribute to: ledger rules: Shelley/Conway spec; consensus: Ouroboros Praos paper
+4. **Explore the codebase**: Dingo is organized around:
+   - `ledger/`: UTxO state, transaction validation
+   - `chainsync/`: chain synchronization using gouroboros
+   - `blockproducer/`: block production for stake pool operators
+   - `api/`: external APIs (UTxO RPC, Blockfrost-compatible REST, Rosetta/Mesh)
+5. **Find a [good first issue](https://github.com/blinklabs-io/node/issues?q=is%3Aopen+label%3A%22good+first+issue%22)**: UTxO validation, API coverage, and test infrastructure are the most accessible areas
+6. **Conformance testing** between Dingo and the Haskell node is high-value work: verifying that both nodes agree on ledger state for the same inputs is a concrete, testable contribution that doesn't require deep Go expertise
+
+## What Makes the Go Path Distinct
+
+**APIs are a first-class concern.** Dingo exposes multiple external APIs out of the box:
+- [UTxO RPC](https://utxorpc.org/): a gRPC-based standard for UTxO chain interaction
+- Blockfrost-compatible REST: drop-in replacement for applications already using Blockfrost
+- Rosetta/Mesh: for exchange and wallet integrations
+
+Contributing to these API layers requires understanding the protocol (what data is available and what it means) but not the deep consensus or ledger math. This is a unique entry point not available in the Haskell or Rust paths.
+
+**Pluggable storage.** Dingo supports multiple storage backends (Badger, SQLite, PostgreSQL, MySQL, cloud storage). Work on storage backends is largely Go-idiomatic without requiring protocol-specific knowledge: a good path for Go developers who want to contribute before diving into the ledger.
+
+## The Formal Specifications
+
+These apply to the Go path just as much as Haskell and Rust:
+
+| Document | What it specifies |
+|---|---|
+| [Shelley Ledger Formal Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | The foundational ledger rules |
+| [Conway Ledger Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | CIP-1694 governance, Conway era rules |
+| [Ouroboros papers](https://iohk.io/en/research/library/) | The consensus protocol proofs |
+
+*Back to [Core Protocol Contributor](./core-protocol-contributor.md): or see [Haskell](./haskell-core-contributor.md) or [Rust](./rust-core-contributor.md).*

--- a/website/docs/how-to-guide/advanced/go-core-contributor.md
+++ b/website/docs/how-to-guide/advanced/go-core-contributor.md
@@ -88,4 +88,6 @@ These apply to the Go path just as much as Haskell and Rust:
 | [Conway Ledger Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | CIP-1694 governance, Conway era rules |
 | [Ouroboros papers](https://iohk.io/en/research/library/) | The consensus protocol proofs |
 
+Dingo and gouroboros are listed in the [Cardano Builder Tools directory](https://developers.cardano.org/tools/) alongside other node and infrastructure projects in the ecosystem.
+
 *Back to [Core Protocol Contributor](./core-protocol-contributor.md): or see [Haskell](./haskell-core-contributor.md) or [Rust](./rust-core-contributor.md).*

--- a/website/docs/how-to-guide/advanced/haskell-core-contributor.md
+++ b/website/docs/how-to-guide/advanced/haskell-core-contributor.md
@@ -1,0 +1,106 @@
+---
+sidebar_position: 5
+title: Haskell Core Contributor
+---
+
+# Haskell Core Contributor
+
+This guide covers contributing to the reference Cardano node implementation: `cardano-ledger`, `ouroboros-consensus`, `cardano-node`, and their companion libraries. This is the Haskell path.
+
+Before reading further, make sure you have read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html): the implementation-independent guide to how the protocol works. It is the best orientation before navigating any of these repositories.
+
+## The Repositories
+
+The core of Cardano is implemented in Haskell across several tightly coupled repositories. Start with `cardano-ledger` for ledger rules or `ouroboros-consensus` for chain selection and block validation: these are the two deepest entry points.
+
+| Repository | What it governs | Issues |
+|---|---|---|
+| [`cardano-ledger`](https://github.com/IntersectMBO/cardano-ledger) | All ledger rules: how transactions are validated, how state transitions work using the STS framework | [Issues](https://github.com/IntersectMBO/cardano-ledger/issues) |
+| [`ouroboros-consensus`](https://github.com/IntersectMBO/ouroboros-consensus) | The Ouroboros consensus algorithm, chain selection, and block validation | [Issues](https://github.com/IntersectMBO/ouroboros-consensus/issues) |
+| [`ouroboros-network`](https://github.com/IntersectMBO/ouroboros-network) | The peer-to-peer networking layer: mini-protocols, connection management | [Issues](https://github.com/IntersectMBO/ouroboros-network/issues) |
+| [`cardano-node`](https://github.com/IntersectMBO/cardano-node) | The node executable that ties ledger, consensus, and networking together | [Issues](https://github.com/IntersectMBO/cardano-node/issues) |
+| [`cardano-api`](https://github.com/IntersectMBO/cardano-api) | High-level Haskell library over ledger/consensus; the interface used by CLI and tooling | [Issues](https://github.com/IntersectMBO/cardano-api/issues) |
+| [`cardano-cli`](https://github.com/IntersectMBO/cardano-cli) | The official command-line interface: good for contributor-friendly Haskell issues | [Issues](https://github.com/IntersectMBO/cardano-cli/issues) |
+| [`cardano-base`](https://github.com/IntersectMBO/cardano-base) | Shared cryptography, slotting, and binary serialization libraries used across the stack | [Issues](https://github.com/IntersectMBO/cardano-base/issues) |
+| [`plutus`](https://github.com/IntersectMBO/plutus) | The Plutus Core language and execution engine: compiler, evaluator, cost models | [Issues](https://github.com/IntersectMBO/plutus/issues) |
+
+When browsing issues, filter by the `good first issue` label to find tasks suitable for new contributors, or by `help wanted` for issues where the team is actively looking for outside input. You can also filter by area (e.g. `ledger`, `consensus`, `testing`) to narrow down to your domain of interest.
+
+> **Important distinction**: The [Plutus Pioneer Program](https://developers.cardano.org/docs/smart-contracts/plutus/) teaches you to write on-chain validators. It does not prepare you to contribute to `cardano-ledger` or `ouroboros-consensus`. These are different jobs. Completing the Plutus Pioneer Program is not a prerequisite here.
+
+## Step 0: The Dependency Wall
+
+Every core Cardano Haskell repository has a complex dependency graph involving GHC version constraints, C library dependencies, cryptographic primitives, and cross-platform linker flags.
+
+**Attempting to resolve this manually will fail.** Depending on your OS and distribution, it ranges from painful to impossible. On NixOS specifically, non-Nix builds do not work by design.
+
+**[Nix](https://nixos.org/download) is the standard working environment.** A `nix develop` invocation drops you into an environment where all dependencies are pinned, present, and working.
+
+Getting started with Nix:
+- [`nix-installer` by Determinate Systems](https://github.com/DeterminateSystems/nix-installer): the recommended installer
+- [`devenv`](https://devenv.sh/): a developer-friendly layer on top of Nix
+- Each repo's `flake.nix` or `shell.nix` defines the development shell: run `nix develop` from the repo root
+
+## The Formal Specifications
+
+The Haskell implementation must match the formal specifications. These are the ground truth.
+
+| Document | What it specifies |
+|---|---|
+| [Shelley Ledger Formal Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | The foundational ledger rules using small-step semantics (STS) |
+| [Conway Ledger Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | CIP-1694 governance, DRep ratification, committee logic |
+| [Ouroboros papers](https://iohk.io/en/research/library/) | The family of consensus protocol proofs (Classic, BFT, Praos, Genesis) |
+
+The STS (small-step semantics) framework that governs all ledger rules is the conceptual backbone of `cardano-ledger`. Understanding it is the difference between reading the code and understanding it.
+
+## Your Most Accessible Entry Point: Testing
+
+You do not need to implement a new ledger rule to make a valuable core contribution. **Writing tests is often where new contributors start**, and it is high-value work.
+
+`cardano-ledger` has substantial test infrastructure built on property-based testing:
+
+- **[Hedgehog](https://github.com/hedgehogqa/haskell-hedgehog)** and **[QuickCheck](https://github.com/nick8325/quickcheck)** are used throughout
+- **Conformance testing**: verifying that alternative implementations (Rust, Go, etc.) match the Haskell ledger rules: is an ongoing effort and a legitimate core contribution
+- The test suite documents expected behavior; writing a test for an existing rule is a concrete, reviewable contribution
+
+**Good first issues in the testing area:**
+- Search for `good first issue` or `testing` labels in [`cardano-ledger` issues](https://github.com/IntersectMBO/cardano-ledger/issues)
+- Look at existing `Spec` modules in `cardano-ledger` to understand the testing patterns
+
+## How to Contribute a CIP
+
+A Cardano Improvement Proposal (CIP) is how many core contributions happen: especially changes to ledger rules, protocol parameters, or cryptographic primitives.
+
+**What becomes a CIP vs. a PR:**
+- Changes that affect the protocol specification → CIP
+- Bug fixes, test additions, or implementation details that don't change the spec → normal PR/issue
+
+**The CIP stages:**
+1. **Proposed**: draft submitted to the [CIPs repository](https://github.com/cardano-foundation/CIPs) as a PR
+2. **Candidate**: reviewed and accepted by CIP editors, open for community comment
+3. **Active**: ratified and incorporated into a hard fork or ecosystem tooling
+
+**Key contacts and venues:**
+- CIP editors review submissions in the CIPs repo PRs
+- Intersect's TSC working groups often discuss CIPs in progress: see [Intersect Working Groups](../../working-group/sessions/q1-2026/07-contributing-intersect/session-notes/readme.md)
+- The `#cip-discussion` channel in the [Cardano Discord](https://discord.gg/cardano) is the informal venue for early feedback
+
+The [CIPs repository README](https://github.com/cardano-foundation/CIPs/blob/master/README.md) has the authoritative process document. Reading a few merged CIPs (CIP-1694, CIP-0381) before writing your own will calibrate your expectations.
+
+## Governance Protocol Work
+
+Governance in Cardano operates at three distinct layers: don't conflate them:
+
+| Layer | What it is | Example work |
+|---|---|---|
+| **Governance participation** | Being a DRep, voting, joining Intersect | Register as a DRep, join a working group |
+| **Governance tooling** | Application development on governance infrastructure | GovTool, Agora, wallet integrations for voting |
+| **Governance protocol** | Core ledger rules governing governance itself | CIP-1694 implementation in `cardano-ledger`, Conway era rules, DRep pulsing, ratification logic |
+
+The Conway era modules in `cardano-ledger` are a good starting point for governance protocol work:
+- [`Cardano.Ledger.Conway.Rules`](https://github.com/IntersectMBO/cardano-ledger/tree/master/eras/conway/impl/src/Cardano/Ledger/Conway/Rules): the STS rules for governance
+- The Conway formal spec (linked above)
+
+For governance participation and tooling, see the [Intersect Membership Guide](../../intersect-membership-guide.md).
+
+*Back to [Core Protocol Contributor](./core-protocol-contributor.md): or continue to [Rust](./rust-core-contributor.md) or [Go](./go-core-contributor.md).*

--- a/website/docs/how-to-guide/advanced/haskell-core-contributor.md
+++ b/website/docs/how-to-guide/advanced/haskell-core-contributor.md
@@ -85,7 +85,7 @@ A Cardano Improvement Proposal (CIP) is how many core contributions happen: espe
 - Intersect's TSC working groups often discuss CIPs in progress: see [Intersect Working Groups](../../working-group/sessions/q1-2026/07-contributing-intersect/session-notes/readme.md)
 - The `#cip-discussion` channel in the Intersect Discord is the informal venue for early feedback. Join Intersect first to get access: see the [Intersect Membership Guide](../../intersect-membership-guide.md)
 
-The [CIPs repository README](https://github.com/cardano-foundation/CIPs/blob/master/README.md) has the authoritative process document. Reading a few merged CIPs (CIP-1694, CIP-0381) before writing your own will calibrate your expectations.
+The [CIPs repository README](https://github.com/cardano-foundation/CIPs/blob/master/README.md) has the authoritative process document. Reading a few merged CIPs (CIP-1694, CIP-0381) before writing your own will calibrate your expectations. You can browse all ratified and draft CIPs at [cips.cardano.org](https://cips.cardano.org/).
 
 ## Governance Protocol Work
 
@@ -100,6 +100,8 @@ Governance in Cardano operates at three distinct layers: don't conflate them:
 The Conway era modules in `cardano-ledger` are a good starting point for governance protocol work:
 - [`Cardano.Ledger.Conway.Rules`](https://github.com/IntersectMBO/cardano-ledger/tree/master/eras/conway/impl/src/Cardano/Ledger/Conway/Rules): the STS rules for governance
 - The Conway formal spec (linked above)
+- [Governance model](https://developers.cardano.org/docs/governance/cardano-governance/governance-model/) — how on-chain governance works end to end
+- [Governance actions](https://developers.cardano.org/docs/governance/cardano-governance/governance-actions/) — the types of actions the ledger can ratify
 
 For governance participation and tooling, see the [Intersect Membership Guide](../../intersect-membership-guide.md).
 

--- a/website/docs/how-to-guide/advanced/haskell-core-contributor.md
+++ b/website/docs/how-to-guide/advanced/haskell-core-contributor.md
@@ -83,7 +83,7 @@ A Cardano Improvement Proposal (CIP) is how many core contributions happen: espe
 **Key contacts and venues:**
 - CIP editors review submissions in the CIPs repo PRs
 - Intersect's TSC working groups often discuss CIPs in progress: see [Intersect Working Groups](../../working-group/sessions/q1-2026/07-contributing-intersect/session-notes/readme.md)
-- The `#cip-discussion` channel in the [Cardano Discord](https://discord.gg/cardano) is the informal venue for early feedback
+- The `#cip-discussion` channel in the Intersect Discord is the informal venue for early feedback. Join Intersect first to get access: see the [Intersect Membership Guide](../../intersect-membership-guide.md)
 
 The [CIPs repository README](https://github.com/cardano-foundation/CIPs/blob/master/README.md) has the authoritative process document. Reading a few merged CIPs (CIP-1694, CIP-0381) before writing your own will calibrate your expectations.
 

--- a/website/docs/how-to-guide/advanced/haskell-core-contributor.md
+++ b/website/docs/how-to-guide/advanced/haskell-core-contributor.md
@@ -9,6 +9,8 @@ This guide covers contributing to the reference Cardano node implementation: `ca
 
 Before reading further, make sure you have read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html): the implementation-independent guide to how the protocol works. It is the best orientation before navigating any of these repositories.
 
+**New to Haskell?** Work through the [IOG Haskell Course](https://github.com/input-output-hk/haskell-course) first. It is a beginner-friendly, 22-lesson curriculum built by IOG that takes you from zero Haskell knowledge to practical productivity, with video lessons and hands-on exercises. It assumes no prior Haskell experience and is specifically designed with Cardano development in mind.
+
 ## The Repositories
 
 The core of Cardano is implemented in Haskell across several tightly coupled repositories. Start with `cardano-ledger` for ledger rules or `ouroboros-consensus` for chain selection and block validation: these are the two deepest entry points.

--- a/website/docs/how-to-guide/advanced/rust-core-contributor.md
+++ b/website/docs/how-to-guide/advanced/rust-core-contributor.md
@@ -1,0 +1,96 @@
+---
+sidebar_position: 6
+title: Rust Core Contributor
+---
+
+# Rust Core Contributor
+
+This guide covers contributing to Cardano's core protocol in Rust: through Amaru (a full node implementation), Pallas (protocol primitives), Dolos (data node), and related projects.
+
+Before reading further, make sure you have read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html). The same protocol the Haskell node implements is what you are implementing in Rust: the Blueprint explains it without assuming any particular language or codebase.
+
+## Choose Your Focus
+
+The key decision is which layer of the stack you want to work on:
+
+| Goal | Start here |
+|---|---|
+| Protocol primitives: CBOR encoding, mini-protocols, ledger types | [Pallas](https://github.com/txpipe/pallas) |
+| Full Rust Cardano node: consensus, ledger, networking | [Amaru](https://github.com/pragma-org/amaru) |
+| Chain data access and indexing at the node level | [Dolos](https://github.com/txpipe/dolos) |
+| Event streaming pipelines from the chain | [Oura](https://github.com/txpipe/oura) |
+| Off-chain transaction building in Rust | [Whisky](https://github.com/sidan-lab/whisky) |
+
+**How these projects relate:**
+
+```
+Pallas (protocol primitives: CBOR, mini-protocols, ledger types)
+  ├── Dolos  (data node built on Pallas)
+  ├── Amaru  (full node: uses Pallas primitives)
+  └── Oura   (event pipeline built on Pallas)
+```
+
+Start with Pallas if you are new to the Cardano protocol. Its primitives are the shared foundation: once you understand CBOR encoding, the UTxO model in Rust types, and the mini-protocol framing, contributing to Amaru or Dolos becomes significantly easier.
+
+## Environment Setup
+
+The Rust path has a much simpler setup than the Haskell path: no Nix required for most projects.
+
+```bash
+# Install the Rust toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Clone and build Pallas (the starting point)
+git clone https://github.com/txpipe/pallas
+cd pallas
+cargo build
+```
+
+Amaru may require additional system dependencies for its storage backends: check the repo's `README` for current setup instructions.
+
+## Progression: Starting with Pallas
+
+Pallas is the most accessible entry point. Its crates are well-documented and independently useful:
+
+1. Clone the repo and run `cargo build`: it just works
+2. Read the [`pallas-primitives`](https://github.com/txpipe/pallas/tree/main/pallas-primitives) crate: this is the Cardano data model in Rust (blocks, transactions, UTxOs)
+3. Read the [`pallas-network`](https://github.com/txpipe/pallas/tree/main/pallas-network) crate: the mini-protocol implementation
+4. Find a [good first issue](https://github.com/txpipe/pallas/issues?q=is%3Aopen+label%3A%22good+first+issue%22) in the codec, network, or traverse modules
+5. Open a PR: review cycles are typically days, not weeks
+
+## Progression: Contributing to Amaru
+
+Amaru is a full, from-scratch Rust implementation of a Cardano node: consensus, ledger rules, and networking. It implements the same formal specifications as the Haskell node, making it both a conformance testing target and a core protocol contribution.
+
+1. **Read the [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html)**: essential before reading Amaru's code
+2. **Read the [Amaru repository](https://github.com/pragma-org/amaru)**: understand how it decomposes the node into ledger, consensus, and network stages
+3. **Read the relevant formal spec** for the area you want to contribute to: ledger rules: Shelley/Conway spec; consensus: Ouroboros Praos paper (same ground truth as the Haskell path)
+4. **Get Pallas familiarity first**: Amaru builds on Pallas types extensively
+5. **Find a [good first issue](https://github.com/pragma-org/amaru/issues?q=is%3Aopen+label%3A%22good+first+issue%22)**: ledger rule implementations and test coverage are the most accessible areas
+6. **Conformance testing** between Amaru and the Haskell node is high-value work that requires understanding the specs but not Haskell fluency: this is a strong first contribution area
+
+> Amaru implements the same formal specifications as the Haskell node. Any work on Amaru's ledger or consensus logic requires reading the same specs as the Haskell path: the Rust path does not skip that step.
+
+## The Formal Specifications
+
+These apply to the Rust path just as much as Haskell:
+
+| Document | What it specifies |
+|---|---|
+| [Shelley Ledger Formal Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | The foundational ledger rules using small-step semantics (STS) |
+| [Conway Ledger Spec](https://github.com/IntersectMBO/cardano-ledger/releases) | CIP-1694 governance, DRep ratification, committee logic |
+| [Ouroboros papers](https://iohk.io/en/research/library/) | The family of consensus protocol proofs (Classic, BFT, Praos, Genesis) |
+
+## Intersect-Funded Rust Projects
+
+Several Rust projects are officially funded under Intersect's [POSM Maintainer Retainer programme](https://committees.docs.intersectmbo.org/intersect-open-source-committee/about/paid-open-source-model-posm/maintainer-retainer/project-list):
+
+| Repository | Maintained by | What it does | Issues |
+|---|---|---|---|
+| [Amaru](https://github.com/pragma-org/amaru) | Pragma | Full Rust Cardano node: consensus, ledger, networking | [Good first issues](https://github.com/pragma-org/amaru/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+| [Pallas](https://github.com/txpipe/pallas) | TxPipe | Protocol primitives: CBOR, mini-protocols, ledger types | [Good first issues](https://github.com/txpipe/pallas/issues?q=is%3Aopen+label%3A%22good+first+issue%22) |
+| [Dolos](https://github.com/txpipe/dolos) | TxPipe | Lightweight data node built on Pallas | [Issues](https://github.com/txpipe/dolos/issues) |
+| [Oura](https://github.com/txpipe/oura) **[MR]** | TxPipe | Event streaming pipeline from the chain | [Issues](https://github.com/txpipe/oura/issues) |
+| [Whisky](https://github.com/sidan-lab/whisky) **[MR]** | Sidan Lab | Off-chain transaction building in Rust | [Issues](https://github.com/sidan-lab/whisky/issues) |
+
+*Back to [Core Protocol Contributor](./core-protocol-contributor.md): or see [Haskell](./haskell-core-contributor.md) or [Go](./go-core-contributor.md).*

--- a/website/docs/how-to-guide/advanced/rust-core-contributor.md
+++ b/website/docs/how-to-guide/advanced/rust-core-contributor.md
@@ -93,4 +93,6 @@ Several Rust projects are officially funded under Intersect's [POSM Maintainer R
 | [Oura](https://github.com/txpipe/oura) **[MR]** | TxPipe | Event streaming pipeline from the chain | [Issues](https://github.com/txpipe/oura/issues) |
 | [Whisky](https://github.com/sidan-lab/whisky) **[MR]** | Sidan Lab | Off-chain transaction building in Rust | [Issues](https://github.com/sidan-lab/whisky/issues) |
 
+For a searchable directory of Rust tools in the Cardano ecosystem (Dolos, Oura, Pallas, Whisky and others), see the [Cardano Builder Tools directory](https://developers.cardano.org/tools/).
+
 *Back to [Core Protocol Contributor](./core-protocol-contributor.md): or see [Haskell](./haskell-core-contributor.md) or [Go](./go-core-contributor.md).*

--- a/website/docs/resources/repositories.md
+++ b/website/docs/resources/repositories.md
@@ -9,19 +9,19 @@ A curated reference of the repositories every Cardano developer should know. Pro
 For guidance on which repos to start with, see the [Cardano Developer Pathway](../working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md).
 
 
-## Core Protocol — Intersect Maintained
+## Core Protocol: Intersect Maintained
 
 These repositories implement the Cardano protocol itself. They are maintained under the [IntersectMBO GitHub org](https://github.com/IntersectMBO) and funded through the POSM Maintainer Retainer programme.
 
 | Repository | Language | What it does |
 |---|---|---|
-| [cardano-node](https://github.com/IntersectMBO/cardano-node) **[MR]** | Haskell | The Cardano node — ties ledger, consensus, and networking together |
+| [cardano-node](https://github.com/IntersectMBO/cardano-node) **[MR]** | Haskell | The Cardano node: ties ledger, consensus, and networking together |
 | [cardano-ledger](https://github.com/IntersectMBO/cardano-ledger) **[MR]** | Haskell | All ledger rules using the STS framework; the ground truth for transaction validation |
 | [ouroboros-network](https://github.com/IntersectMBO/ouroboros-network) **[MR]** | Haskell | The Ouroboros consensus algorithm, chain selection, and the p2p networking layer |
 | [cardano-api](https://github.com/IntersectMBO/cardano-api) **[MR]** | Haskell | High-level Haskell library over ledger and consensus; used by the node, CLI, and tooling |
 | [cardano-cli](https://github.com/IntersectMBO/cardano-cli) **[MR]** | Haskell | Official command-line interface for interacting with a Cardano node |
 | [cardano-db-sync](https://github.com/IntersectMBO/cardano-db-sync) **[MR]** | Haskell | Follows the chain and mirrors it into PostgreSQL for querying |
-| [plutus](https://github.com/IntersectMBO/plutus) **[MR]** | Haskell | The Plutus smart contract platform — Plutus Core language and execution engine |
+| [plutus](https://github.com/IntersectMBO/plutus) **[MR]** | Haskell | The Plutus smart contract platform: Plutus Core language and execution engine |
 | [cardano-base](https://github.com/IntersectMBO/cardano-base) **[MR]** | Haskell | Shared base libraries used across the core Cardano codebase (crypto, slotting, binary) |
 | [lsm-tree](https://github.com/IntersectMBO/lsm-tree) **[MR]** | Haskell | Log-structured merge-tree implementation; the storage backend for the UTxO set in future node versions |
 | [cardano-node-emulator](https://github.com/IntersectMBO/cardano-node-emulator) **[MR]** | Haskell | In-process Cardano node emulator for testing smart contracts without a real node |
@@ -31,15 +31,15 @@ These repositories implement the Cardano protocol itself. They are maintained un
 > **Contributing to core repos**: See the [Core Protocol Contributor Guide](../how-to-guide/advanced/core-protocol-contributor.md) for environment setup (Nix is required), formal specifications, and accessible first contributions.
 
 
-## Community Projects — Intersect Maintained
+## Community Projects: Intersect Maintained
 
 Community-built projects also funded under the POSM Maintainer Retainer programme.
 
 | Repository | Language | What it does |
 |---|---|---|
-| [cardano-scaling/hydra](https://github.com/cardano-scaling/hydra) **[MR]** | Haskell | Hydra Head — Layer 2 isomorphic state channel protocol for fast, cheap transactions |
+| [cardano-scaling/hydra](https://github.com/cardano-scaling/hydra) **[MR]** | Haskell | Hydra Head: Layer 2 isomorphic state channel protocol for fast, cheap transactions |
 | [IntersectMBO/evolution-sdk](https://github.com/IntersectMBO/evolution-sdk) **[MR]** | Haskell | SDK for building on-chain governance and protocol evolution tooling |
-| [MeshJS/mesh](https://github.com/MeshJS/mesh) **[MR]** | TypeScript | Full-featured TypeScript SDK — transactions, wallet connections, React components |
+| [MeshJS/mesh](https://github.com/MeshJS/mesh) **[MR]** | TypeScript | Full-featured TypeScript SDK: transactions, wallet connections, React components |
 | [MeshJS/multisig](https://github.com/MeshJS/multisig) **[MR]** | TypeScript | Multi-signature transaction coordination built on Mesh |
 | [txpipe/oura](https://github.com/txpipe/oura) **[MR]** | Rust | Pipeline tool for streaming and filtering Cardano chain events |
 | [cardano-foundation/cardano-wallet](https://github.com/cardano-foundation/cardano-wallet) **[MR]** | Haskell | Reference wallet backend with REST API; used by hardware wallets and exchanges |
@@ -56,7 +56,7 @@ On-chain validator languages that compile to Plutus Core. Not all require Haskel
 
 | Repository | Language | Notes |
 |---|---|---|
-| [aiken-lang/aiken](https://github.com/aiken-lang/aiken) | Aiken | Recommended for new projects — Rust-like syntax, strong toolchain, active community |
+| [aiken-lang/aiken](https://github.com/aiken-lang/aiken) | Aiken | Recommended for new projects: Rust-like syntax, strong toolchain, active community |
 | [Hyperion-BT/Helios](https://github.com/Hyperion-BT/Helios) | Helios | TypeScript-like syntax; good for frontend-first developers |
 | [OpShin/opshin](https://github.com/OpShin/opshin) | Python | Write validators in a subset of Python |
 | [nau/scalus](https://github.com/nau/scalus) | Scala | JVM-based smart contract language targeting Plutus Core |
@@ -84,25 +84,27 @@ Data access tools, indexers, and Rust protocol implementations.
 
 | Repository | Language | What it does |
 |---|---|---|
-| [pragma-org/amaru](https://github.com/pragma-org/amaru) | Rust | Full Rust Cardano node — implements consensus, ledger rules, and networking from scratch against the same formal specs as the Haskell node. The most ambitious Rust core contribution target |
-| [txpipe/pallas](https://github.com/txpipe/pallas) | Rust | Rust protocol primitives — CBOR codec, chain sync, ledger types, mini-protocols. Most accessible Rust entry point for core contribution |
+| [pragma-org/amaru](https://github.com/pragma-org/amaru) | Rust | Full Rust Cardano node: implements consensus, ledger rules, and networking from scratch against the same formal specs as the Haskell node |
+| [blinklabs-io/node](https://github.com/blinklabs-io/node) | Go | **Dingo**: full Go Cardano node by Blink Labs: chain sync, UTxO tracking, Plutus V1/V2/V3, block production, pluggable storage (testnet/devnet, not yet mainnet) |
+| [blinklabs-io/gouroboros](https://github.com/blinklabs-io/gouroboros) | Go | Go implementation of the Ouroboros networking protocol: mini-protocols, connection multiplexing, CBOR codec; used as the networking layer in Dingo |
+| [txpipe/pallas](https://github.com/txpipe/pallas) | Rust | Rust protocol primitives: CBOR codec, chain sync, ledger types, mini-protocols. Most accessible Rust entry point for core contribution |
 | [txpipe/dolos](https://github.com/txpipe/dolos) | Rust | Lightweight Cardano data node built on Pallas; designed for read-heavy workloads |
 | [CardanoSolutions/ogmios](https://github.com/CardanoSolutions/ogmios) | Haskell | WebSocket bridge to cardano-node; exposes mini-protocols as a JSON/WebSocket API |
-| [CardanoSolutions/kupo](https://github.com/CardanoSolutions/kupo) | Haskell | Fast, lightweight chain indexer — indexes UTxOs by address or script |
+| [CardanoSolutions/kupo](https://github.com/CardanoSolutions/kupo) | Haskell | Fast, lightweight chain indexer: indexes UTxOs by address or script |
 | [bloxbean/yaci-devkit](https://github.com/bloxbean/yaci-devkit) | Java | Local Cardano devnet toolkit; spins up a private network for testing in seconds |
 | [bloxbean/yaci-store](https://github.com/bloxbean/yaci-store) | Java | Modular chain indexer built on the Yaci CBOR parser |
 
-> Amaru, Pallas, and Dolos are **core protocol infrastructure**, not Layer 2 — they implement the Cardano protocol in Rust. Amaru is a full node; Pallas provides the underlying protocol primitives both Dolos and Amaru build on. See the [Core Protocol Contributor Guide](../how-to-guide/advanced/core-protocol-contributor.md) for the Rust contribution path.
+> Amaru (Rust), Dingo (Go), Pallas, and Dolos are **core protocol infrastructure**, not Layer 2: they implement the Cardano protocol in alternative languages. See the [Core Protocol Contributor](../how-to-guide/advanced/core-protocol-contributor.md) overview for language-specific guides.
 
 
 ## Governance & Standards
 
 | Repository | What it does |
 |---|---|
-| [cardano-foundation/CIPs](https://github.com/cardano-foundation/CIPs) | Cardano Improvement Proposals — the formal process for protocol changes and standards |
+| [cardano-foundation/CIPs](https://github.com/cardano-foundation/CIPs) | Cardano Improvement Proposals: the formal process for protocol changes and standards |
 | [Liqwid-Labs/agora](https://github.com/Liqwid-Labs/agora) | On-chain governance framework for DAOs built on Cardano |
 
-> For the CIP contribution process — stages, editors, what qualifies — see the [Core Protocol Contributor Guide](../how-to-guide/advanced/core-protocol-contributor.md#how-to-contribute-a-cip).
+> For the CIP contribution process: stages, editors, what qualifies: see the [Core Protocol Contributor Guide](../how-to-guide/advanced/core-protocol-contributor.md#how-to-contribute-a-cip).
 
 
 ## Developer Tools & Testing
@@ -118,8 +120,8 @@ Data access tools, indexers, and Rust protocol implementations.
 
 | Repository | What it does |
 |---|---|
-| [IntersectMBO/developer-experience](https://github.com/IntersectMBO/developer-experience) | This documentation site — developer guides, working group sessions, and onboarding resources |
+| [IntersectMBO/developer-experience](https://github.com/IntersectMBO/developer-experience) | This documentation site: developer guides, working group sessions, and onboarding resources |
 
-Contributions welcome — see the [Contributing Guidelines](https://github.com/IntersectMBO/developer-experience/blob/main/CONTRIBUTING.md).
+Contributions welcome: see the [Contributing Guidelines](https://github.com/IntersectMBO/developer-experience/blob/main/CONTRIBUTING.md).
 
 *Missing a repository? Open an issue or PR on [IntersectMBO/developer-experience](https://github.com/IntersectMBO/developer-experience).*

--- a/website/docs/resources/repositories.md
+++ b/website/docs/resources/repositories.md
@@ -4,19 +4,122 @@ sidebar_position: 1
 
 # Essential Cardano Repositories
 
-## Coming Soon
+A curated reference of the repositories every Cardano developer should know. Projects marked with **[MR]** are officially funded under Intersect's [Paid Open Source Model (POSM) Maintainer Retainer programme](https://committees.docs.intersectmbo.org/intersect-open-source-committee/about/paid-open-source-model-posm/maintainer-retainer/project-list).
 
-This page will provide a comprehensive guide to essential Cardano repositories for developers.
+For guidance on which repos to start with, see the [Cardano Developer Pathway](../working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md).
 
-### What You'll Find
-- Core Cardano repositories and their purposes
-- Smart contract development repositories
-- Developer tools and SDKs
-- Community-maintained projects
-- Testing and quality assurance tools
 
-**Status**: Content in development
+## Core Protocol — Intersect Maintained
 
----
+These repositories implement the Cardano protocol itself. They are maintained under the [IntersectMBO GitHub org](https://github.com/IntersectMBO) and funded through the POSM Maintainer Retainer programme.
 
-*This resource guide is part of the Cardano Developer Experience Working Group initiative.*
+| Repository | Language | What it does |
+|---|---|---|
+| [cardano-node](https://github.com/IntersectMBO/cardano-node) **[MR]** | Haskell | The Cardano node — ties ledger, consensus, and networking together |
+| [cardano-ledger](https://github.com/IntersectMBO/cardano-ledger) **[MR]** | Haskell | All ledger rules using the STS framework; the ground truth for transaction validation |
+| [ouroboros-network](https://github.com/IntersectMBO/ouroboros-network) **[MR]** | Haskell | The Ouroboros consensus algorithm, chain selection, and the p2p networking layer |
+| [cardano-api](https://github.com/IntersectMBO/cardano-api) **[MR]** | Haskell | High-level Haskell library over ledger and consensus; used by the node, CLI, and tooling |
+| [cardano-cli](https://github.com/IntersectMBO/cardano-cli) **[MR]** | Haskell | Official command-line interface for interacting with a Cardano node |
+| [cardano-db-sync](https://github.com/IntersectMBO/cardano-db-sync) **[MR]** | Haskell | Follows the chain and mirrors it into PostgreSQL for querying |
+| [plutus](https://github.com/IntersectMBO/plutus) **[MR]** | Haskell | The Plutus smart contract platform — Plutus Core language and execution engine |
+| [cardano-base](https://github.com/IntersectMBO/cardano-base) **[MR]** | Haskell | Shared base libraries used across the core Cardano codebase (crypto, slotting, binary) |
+| [lsm-tree](https://github.com/IntersectMBO/lsm-tree) **[MR]** | Haskell | Log-structured merge-tree implementation; the storage backend for the UTxO set in future node versions |
+| [cardano-node-emulator](https://github.com/IntersectMBO/cardano-node-emulator) **[MR]** | Haskell | In-process Cardano node emulator for testing smart contracts without a real node |
+| [cardano-prelude](https://github.com/IntersectMBO/cardano-prelude) **[MR]** | Haskell | Custom Prelude shared across core Haskell repos |
+| [antaeus](https://github.com/IntersectMBO/antaeus) **[MR]** | Haskell | End-to-end integration tests for Plutus scripts against a live node |
+
+> **Contributing to core repos**: See the [Core Protocol Contributor Guide](../how-to-guide/advanced/core-protocol-contributor.md) for environment setup (Nix is required), formal specifications, and accessible first contributions.
+
+
+## Community Projects — Intersect Maintained
+
+Community-built projects also funded under the POSM Maintainer Retainer programme.
+
+| Repository | Language | What it does |
+|---|---|---|
+| [cardano-scaling/hydra](https://github.com/cardano-scaling/hydra) **[MR]** | Haskell | Hydra Head — Layer 2 isomorphic state channel protocol for fast, cheap transactions |
+| [IntersectMBO/evolution-sdk](https://github.com/IntersectMBO/evolution-sdk) **[MR]** | Haskell | SDK for building on-chain governance and protocol evolution tooling |
+| [MeshJS/mesh](https://github.com/MeshJS/mesh) **[MR]** | TypeScript | Full-featured TypeScript SDK — transactions, wallet connections, React components |
+| [MeshJS/multisig](https://github.com/MeshJS/multisig) **[MR]** | TypeScript | Multi-signature transaction coordination built on Mesh |
+| [txpipe/oura](https://github.com/txpipe/oura) **[MR]** | Rust | Pipeline tool for streaming and filtering Cardano chain events |
+| [cardano-foundation/cardano-wallet](https://github.com/cardano-foundation/cardano-wallet) **[MR]** | Haskell | Reference wallet backend with REST API; used by hardware wallets and exchanges |
+| [Plutonomicon/plutarch-plutus](https://github.com/Plutonomicon/plutarch-plutus) **[MR]** | Haskell | Embedded DSL in Haskell for writing Plutus validators; maximally expressive |
+| [sidan-lab/whisky](https://github.com/sidan-lab/whisky) **[MR]** | Rust | Rust SDK for building and signing Cardano transactions |
+| [sidan-lab/vodka](https://github.com/sidan-lab/vodka) **[MR]** | Haskell | Aiken test utilities and off-chain helpers for smart contract development |
+| [GameChangerFinance/dandelion-lite](https://github.com/GameChangerFinance/dandelion-lite) **[MR]** | TypeScript | Lightweight Cardano API gateway and wallet connectivity layer |
+| [Andamio-Platform/andamio-app-template](https://github.com/Andamio-Platform/andamio-app-template) **[MR]** | TypeScript | Template for building on the Andamio learning and contribution management platform |
+
+
+## Smart Contract Languages
+
+On-chain validator languages that compile to Plutus Core. Not all require Haskell knowledge.
+
+| Repository | Language | Notes |
+|---|---|---|
+| [aiken-lang/aiken](https://github.com/aiken-lang/aiken) | Aiken | Recommended for new projects — Rust-like syntax, strong toolchain, active community |
+| [Hyperion-BT/Helios](https://github.com/Hyperion-BT/Helios) | Helios | TypeScript-like syntax; good for frontend-first developers |
+| [OpShin/opshin](https://github.com/OpShin/opshin) | Python | Write validators in a subset of Python |
+| [nau/scalus](https://github.com/nau/scalus) | Scala | JVM-based smart contract language targeting Plutus Core |
+| [Python-Cardano/pycardano](https://github.com/Python-Cardano/pycardano) | Python | Python library covering off-chain transaction building and simple script support |
+| [input-output-hk/marlowe-cardano](https://github.com/input-output-hk/marlowe-cardano) | Marlowe | Domain-specific language for financial contracts; no Haskell required |
+| [input-output-hk/plutus-pioneer-program](https://github.com/input-output-hk/plutus-pioneer-program) | Haskell | Course materials for learning Plutus directly |
+
+
+## Off-Chain SDKs & Libraries
+
+Libraries for building transaction logic, wallet integrations, and dApp frontends.
+
+| Repository | Language | What it does |
+|---|---|---|
+| [Anastasia-Labs/lucid-evolution](https://github.com/Anastasia-Labs/lucid-evolution) | TypeScript | Actively maintained fork of Lucid; clean API for building and signing transactions |
+| [butaneprotocol/blaze-cardano](https://github.com/butaneprotocol/blaze-cardano) | TypeScript | Transaction builder with a provider-agnostic design |
+| [Emurgo/cardano-serialization-lib](https://github.com/Emurgo/cardano-serialization-lib) | Rust/WASM | Low-level serialization library; used internally by many SDKs |
+| [Plutonomicon/cardano-transaction-lib](https://github.com/Plutonomicon/cardano-transaction-lib) | PureScript | PureScript SDK for building Plutus dApp frontends |
+| [cardano-foundation/cardano-connect-with-wallet](https://github.com/cardano-foundation/cardano-connect-with-wallet) | TypeScript | React component library for CIP-30 wallet connections |
+
+
+## Infrastructure & Indexers
+
+Data access tools, indexers, and Rust protocol implementations.
+
+| Repository | Language | What it does |
+|---|---|---|
+| [pragma-org/amaru](https://github.com/pragma-org/amaru) | Rust | Full Rust Cardano node — implements consensus, ledger rules, and networking from scratch against the same formal specs as the Haskell node. The most ambitious Rust core contribution target |
+| [txpipe/pallas](https://github.com/txpipe/pallas) | Rust | Rust protocol primitives — CBOR codec, chain sync, ledger types, mini-protocols. Most accessible Rust entry point for core contribution |
+| [txpipe/dolos](https://github.com/txpipe/dolos) | Rust | Lightweight Cardano data node built on Pallas; designed for read-heavy workloads |
+| [CardanoSolutions/ogmios](https://github.com/CardanoSolutions/ogmios) | Haskell | WebSocket bridge to cardano-node; exposes mini-protocols as a JSON/WebSocket API |
+| [CardanoSolutions/kupo](https://github.com/CardanoSolutions/kupo) | Haskell | Fast, lightweight chain indexer — indexes UTxOs by address or script |
+| [bloxbean/yaci-devkit](https://github.com/bloxbean/yaci-devkit) | Java | Local Cardano devnet toolkit; spins up a private network for testing in seconds |
+| [bloxbean/yaci-store](https://github.com/bloxbean/yaci-store) | Java | Modular chain indexer built on the Yaci CBOR parser |
+
+> Amaru, Pallas, and Dolos are **core protocol infrastructure**, not Layer 2 — they implement the Cardano protocol in Rust. Amaru is a full node; Pallas provides the underlying protocol primitives both Dolos and Amaru build on. See the [Core Protocol Contributor Guide](../how-to-guide/advanced/core-protocol-contributor.md) for the Rust contribution path.
+
+
+## Governance & Standards
+
+| Repository | What it does |
+|---|---|
+| [cardano-foundation/CIPs](https://github.com/cardano-foundation/CIPs) | Cardano Improvement Proposals — the formal process for protocol changes and standards |
+| [Liqwid-Labs/agora](https://github.com/Liqwid-Labs/agora) | On-chain governance framework for DAOs built on Cardano |
+
+> For the CIP contribution process — stages, editors, what qualifies — see the [Core Protocol Contributor Guide](../how-to-guide/advanced/core-protocol-contributor.md#how-to-contribute-a-cip).
+
+
+## Developer Tools & Testing
+
+| Repository | Language | What it does |
+|---|---|---|
+| [IntersectMBO/cardano-node-tests](https://github.com/IntersectMBO/cardano-node-tests) | Python | System-level integration and regression tests for cardano-node |
+| [MeshJS/examples](https://github.com/MeshJS/examples) | TypeScript | Working examples for common Mesh patterns |
+| [lidonation/Cardano-mcp](https://github.com/lidonation/Cardano-mcp) | TypeScript | MCP server exposing Cardano chain data to AI assistants |
+
+
+## This Repository
+
+| Repository | What it does |
+|---|---|
+| [IntersectMBO/developer-experience](https://github.com/IntersectMBO/developer-experience) | This documentation site — developer guides, working group sessions, and onboarding resources |
+
+Contributions welcome — see the [Contributing Guidelines](https://github.com/IntersectMBO/developer-experience/blob/main/CONTRIBUTING.md).
+
+*Missing a repository? Open an issue or PR on [IntersectMBO/developer-experience](https://github.com/IntersectMBO/developer-experience).*

--- a/website/docs/working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md
+++ b/website/docs/working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md
@@ -27,7 +27,7 @@ Web2 background
   → Catalyst funding for your project
 ```
 
-**Resources**: [Beginner Guides](../../../../how-to-guide/beginner/), [Aiken](https://aiken-lang.org/), [Cardano Developer Portal](https://developers.cardano.org/)
+**Resources**: [Beginner Guides](../../../../how-to-guide/beginner/), [Aiken](https://aiken-lang.org/), [Smart Contracts overview](https://developers.cardano.org/docs/build/smart-contracts/overview/), [Native Tokens](https://developers.cardano.org/docs/build/native-tokens/overview/), [Wallet & payment integration](https://developers.cardano.org/docs/build/integrate/overview/), [Client SDKs](https://developers.cardano.org/docs/get-started/client-sdks/overview/)
 
 ---
 
@@ -42,7 +42,7 @@ Systems/backend background
   → Build block explorers, monitoring, or custom data pipelines
 ```
 
-**Resources**: [cardano-db-sync guide](../../../../how-to-guide/advanced/cardano-db-sync.md), [cardano-api guide](../../../../how-to-guide/advanced/cardano-api.md), [Yaci DevKit](../../../../how-to-guide/advanced/)
+**Resources**: [cardano-db-sync guide](../../../../how-to-guide/advanced/cardano-db-sync.md), [cardano-api guide](../../../../how-to-guide/advanced/cardano-api.md), [Yaci DevKit](../../../../how-to-guide/advanced/), [Installing cardano-node](https://developers.cardano.org/docs/get-started/infrastructure/node/installing-cardano-node/), [Infrastructure overview](https://developers.cardano.org/docs/get-started/infrastructure/overview/), [Operate a Stake Pool](https://developers.cardano.org/docs/operate-a-stake-pool/)
 
 ---
 

--- a/website/docs/working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md
+++ b/website/docs/working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md
@@ -4,3 +4,104 @@ sidebar_position: 1
 ---
 
 # Cardano Developer Pathway
+
+The Cardano developer pathway is **not a single linear progression**. Depending on your background and goals, you enter at a different point and follow a different track. The four tracks below exist in parallel — none is a prerequisite for another.
+
+---
+
+## The Four Tracks
+
+### Track 1 — dApp & Smart Contracts
+**Who it's for**: Web2 developers, JavaScript/TypeScript engineers, product builders coming from traditional software.
+
+```
+Web2 background
+  → Cardano concepts (UTxO model, native assets, eras)
+  → Choose a smart contract language:
+      - Aiken (recommended for new projects, Rust-like syntax)
+      - Helios (TypeScript-like)
+      - Plutus/Haskell (most expressive, steepest curve)
+  → First smart contract (1 week)
+  → Full-stack dApp with frontend + wallet integration (4–8 weeks)
+  → Mainnet deployment
+  → Catalyst funding for your project
+```
+
+**Resources**: [Beginner Guides](../../../../how-to-guide/beginner/), [Aiken](https://aiken-lang.org/), [Cardano Developer Portal](https://developers.cardano.org/)
+
+---
+
+### Track 2 — Infrastructure & DevOps
+**Who it's for**: Backend engineers, DevOps, developers building indexers, block explorers, APIs, or running nodes.
+
+```
+Systems/backend background
+  → Run a Cardano node (cardano-node)
+  → Choose an indexer: DB Sync, Kupo, Scrolls, Oura
+  → Expose data via API: Ogmios, cardano-graphql
+  → Build block explorers, monitoring, or custom data pipelines
+```
+
+**Resources**: [cardano-db-sync guide](../../../../how-to-guide/advanced/cardano-db-sync.md), [cardano-api guide](../../../../how-to-guide/advanced/cardano-api.md), [Yaci DevKit](../../../../how-to-guide/advanced/)
+
+---
+
+### Track 3 — Core Protocol (Haskell)
+**Who it's for**: Systems engineers, PL researchers, formal methods practitioners, experienced Haskell developers who want to contribute to `cardano-ledger`, `ouroboros-consensus`, or `cardano-node`.
+
+```
+Haskell / FP / systems background
+  → Set up Nix development environment (the required first step)
+  → Read the formal ledger specification (STS framework)
+  → Navigate cardano-ledger module structure
+  → Write tests for existing ledger rules (accessible first contribution)
+  → Contribute to ledger rules, consensus, or cardano-api
+  → Author or co-author a CIP for protocol-level changes
+```
+
+> Note: The Plutus Pioneer Program teaches on-chain validator development, not ledger/consensus contribution. These are different jobs.
+
+**Resources**: [Core Protocol Contributor Guide](../../../../how-to-guide/advanced/core-protocol-contributor.md)
+
+---
+
+### Track 4 — Core Protocol (Rust)
+**Who it's for**: Rust developers who want to contribute to the protocol at the implementation level via Pallas, Dolos, or conformance test infrastructure.
+
+```
+Rust background
+  → Clone Pallas or Dolos
+  → Set up development environment (simpler than Haskell path — no Nix required)
+  → Find a good first issue
+  → Contribute to CBOR codec, chain sync, ledger types, or conformance tests
+  → Cross-implementation conformance testing against Haskell reference
+```
+
+> Pallas and Dolos are **core protocol infrastructure**, not Layer 2. They are Rust re-implementations of core Cardano components.
+
+**Resources**: [Core Protocol Contributor Guide](../../../../how-to-guide/advanced/core-protocol-contributor.md), [Pallas](https://github.com/txpipe/pallas), [Dolos](https://github.com/txpipe/dolos)
+
+---
+
+## Governance Contribution (Cross-Track)
+
+Governance work spans three layers — pick the one that matches your intent:
+
+| Layer | What it involves |
+|---|---|
+| **Participation** | Register as a DRep, vote, join Intersect working groups |
+| **Tooling** | Build on GovTool, Agora, wallet voting integrations |
+| **Protocol** | Contribute to Conway era ledger rules, CIP-1694 implementation |
+
+For participation: [Intersect Membership Guide](../../../../intersect-membership-guide.md)  
+For protocol work: [Core Protocol Contributor Guide](../../../../how-to-guide/advanced/core-protocol-contributor.md)
+
+---
+
+## Contributing to Intersect Working Groups
+
+Every track eventually intersects with Intersect MBO's working groups — where CIPs get prioritized, protocol changes get funded, and community voices are collected. See [Session 07: Contributing to Intersect](../07-contributing-intersect/session-notes/readme.md) for how to find and join working groups.
+
+---
+
+*Session 12 of the Q1 2026 Developer Experience Working Group.*

--- a/website/docs/working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md
+++ b/website/docs/working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md
@@ -61,7 +61,7 @@ Haskell / FP / systems background
 
 > Note: The Plutus Pioneer Program teaches on-chain validator development, not ledger/consensus contribution. These are different jobs.
 
-**Resources**: [Core Protocol Contributor Guide](../../../../how-to-guide/advanced/core-protocol-contributor.md)
+**Resources**: [Core Protocol Contributor Guide](../../../../how-to-guide/advanced/core-protocol-contributor.md), [IOG Haskell Course](https://github.com/input-output-hk/haskell-course) (beginner-friendly, 22 lessons, no prior Haskell required)
 
 ---
 

--- a/website/docs/working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md
+++ b/website/docs/working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md
@@ -5,13 +5,13 @@ sidebar_position: 1
 
 # Cardano Developer Pathway
 
-The Cardano developer pathway is **not a single linear progression**. Depending on your background and goals, you enter at a different point and follow a different track. The four tracks below exist in parallel — none is a prerequisite for another.
+The Cardano developer pathway is **not a single linear progression**. Depending on your background and goals, you enter at a different point and follow a different track. The four tracks below exist in parallel: none is a prerequisite for another.
 
 ---
 
 ## The Four Tracks
 
-### Track 1 — dApp & Smart Contracts
+### Track 1: dApp & Smart Contracts
 **Who it's for**: Web2 developers, JavaScript/TypeScript engineers, product builders coming from traditional software.
 
 ```
@@ -31,7 +31,7 @@ Web2 background
 
 ---
 
-### Track 2 — Infrastructure & DevOps
+### Track 2: Infrastructure & DevOps
 **Who it's for**: Backend engineers, DevOps, developers building indexers, block explorers, APIs, or running nodes.
 
 ```
@@ -46,7 +46,7 @@ Systems/backend background
 
 ---
 
-### Track 3 — Core Protocol (Haskell)
+### Track 3: Core Protocol (Haskell)
 **Who it's for**: Systems engineers, PL researchers, formal methods practitioners, experienced Haskell developers who want to contribute to `cardano-ledger`, `ouroboros-consensus`, or `cardano-node`.
 
 ```
@@ -65,13 +65,13 @@ Haskell / FP / systems background
 
 ---
 
-### Track 4 — Core Protocol (Rust)
+### Track 4: Core Protocol (Rust)
 **Who it's for**: Rust developers who want to contribute to the protocol at the implementation level via Pallas, Dolos, or conformance test infrastructure.
 
 ```
 Rust background
   → Clone Pallas or Dolos
-  → Set up development environment (simpler than Haskell path — no Nix required)
+  → Set up development environment (simpler than Haskell path: no Nix required)
   → Find a good first issue
   → Contribute to CBOR codec, chain sync, ledger types, or conformance tests
   → Cross-implementation conformance testing against Haskell reference
@@ -85,7 +85,7 @@ Rust background
 
 ## Governance Contribution (Cross-Track)
 
-Governance work spans three layers — pick the one that matches your intent:
+Governance work spans three layers: pick the one that matches your intent:
 
 | Layer | What it involves |
 |---|---|
@@ -100,7 +100,7 @@ For protocol work: [Core Protocol Contributor Guide](../../../../how-to-guide/ad
 
 ## Contributing to Intersect Working Groups
 
-Every track eventually intersects with Intersect MBO's working groups — where CIPs get prioritized, protocol changes get funded, and community voices are collected. See [Session 07: Contributing to Intersect](../07-contributing-intersect/session-notes/readme.md) for how to find and join working groups.
+Every track eventually intersects with Intersect MBO's working groups: where CIPs get prioritized, protocol changes get funded, and community voices are collected. See [Session 07: Contributing to Intersect](../07-contributing-intersect/session-notes/readme.md) for how to find and join working groups.
 
 ---
 


### PR DESCRIPTION
## Description

This PR addresses a structural gap in the developer pathway: the core protocol contributor path was largely absent, and what little existed was buried under the dApp track rather than being a parallel entry point.

The changes add a dedicated section for core protocol contribution covering three language paths (Haskell, Rust, Go), populate the essential repositories page from the official Intersect POSM project list, and fill in the previously empty Session 12 pathway page.

## Related Issue

Related to #201

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Changes Made

**New pages**
- `how-to-guide/advanced/core-protocol-contributor.md` — slim overview with language path selector and the Cardano Blueprint as the shared starting point
- `how-to-guide/advanced/haskell-core-contributor.md` — full Haskell path: 8 core IntersectMBO repos, Nix environment setup, formal specifications, STS framework, testing as an entry point, CIP contribution process, governance protocol layers
- `how-to-guide/advanced/rust-core-contributor.md` — Rust path: Amaru (full node, Pragma), Pallas/Dolos/Oura (TxPipe), step-by-step progressions for both Pallas and Amaru, formal specs, Intersect-funded projects
- `how-to-guide/advanced/go-core-contributor.md` — Go path: Dingo (Blink Labs full node) and gouroboros, environment setup, API layer as a unique entry point, conformance testing

**Updated pages**
- `resources/repositories.md` — populated from the official [Intersect POSM Maintainer Retainer project list](https://committees.docs.intersectmbo.org/intersect-open-source-committee/about/paid-open-source-model-posm/maintainer-retainer/project-list); adds Amaru, Dingo, gouroboros, and all POSM-funded community projects; all 84 external URLs verified live
- `how-to-guide/advanced/README.md` — updated to list all three language-specific pages
- `getting-started.md` — adds Core Protocol as a parallel track in the learning path table alongside dApp and Infrastructure
- `working-group/sessions/q1-2026/12-cardano-developer-pathway/readme.md` — was empty; now documents the four parallel developer tracks with entry conditions and links

## Checklist

- [x] I have performed a self-review of my own changes.
- [x] All external links verified (84 URLs checked; 2 broken links fixed: `IntersectMBO/plutus-pioneer-program` corrected to `input-output-hk`, `aiken-lang/aiken-starter-kit` removed as repo does not exist).
- [x] All internal relative links verified against the file system.
- [x] No content duplicated: existing pages (membership guide, session-7 contributing notes, CONTRIBUTING.md) are linked to rather than repeated.
- [x] I have updated the documentation.
