### PR TITLE
docs: revise language-inclusive onboarding guide for clarity and focu…

### DIFF
--- a/DA Milestones/Dan/Q22026/devex-wg-leadership-and-osc-reporting.md
+++ b/DA Milestones/Dan/Q22026/devex-wg-leadership-and-osc-reporting.md
@@ -1,0 +1,167 @@
+# Developer Experience Working Group: Leadership & OSC Reporting
+
+**Milestone:** Participate / Lead Developer Experience Working Group (Q2 2026)
+**Goal:** Establish and sustain DevEx WG meeting cadence, grow participation, and provide regular progress updates to the Open Source Committee (OSC)
+**Author:** Dan Baruka, Developer Advocate, Developer Experience Working Group
+**Status:** Completed
+
+---
+
+## Executive summary
+
+This document tracks Q2 2026 progress against the DevEx WG leadership milestone. The working group runs recurring sessions for Cardano developer onboarding and advocacy; Developer Advocates hold a standing block on the OSC agenda for regular updates.
+
+The deliverable has three pillars:
+
+1. **Cadence & participation**: maintain a predictable session schedule and actively seek contributor participation.
+2. **OSC reporting**: submit a common progress report to the OSC every four weeks, with Developer Advocates alternating monthly.
+3. **Strategic inputs**: maintain a shared record of developer-experience pain points (with an improvement plan) and produce draft documentation for Core Cardano repositories for review by OSC, TSC, and relevant Technical Working Group members.
+
+---
+
+## Task description
+
+Participate in and help lead the Developer Experience Working Group. This includes:
+
+- Establishing and maintaining the group's **meeting cadence**
+- **Seeking participation** from newcomers, contributors, and Technical Working Group representatives
+- Using the **OSC agenda block** allocated to Developer Advocates to provide regular working-group updates
+
+---
+
+## Acceptance criteria
+
+| Criterion | How it is met | Evidence / location |
+|-----------|---------------|---------------------|
+| DevEx WG progress reported to OSC **every four weeks** | Developer Advocates alternate monthly; consolidated report submitted on the OSC cadence | [OSC reporting schedule](#osc-reporting-schedule) · [`../../DevEx-WG-Overview/Q1-2025.md`](../../DevEx-WG-Overview/Q1-2025.md) |
+| **Alternating Developer Advocate** monthly | Advocates contribute sections to each monthly report | [Reporting rotation](#reporting-rotation) |
+| **Pain points record** with improvement plan for OSC Open Source Strategy | Single common document maintained in this repo, updated as pain points are validated or resolved | [`developer-experience-pain-points-and-solutions.md`](developer-experience-pain-points-and-solutions.md) |
+| **One common document** shared with OSC | Shared DevEx report consolidates WG status, pain points, and next actions, not per-advocate silos | [`../../DevEx-WG-Overview/Q1-2025.md`](../../DevEx-WG-Overview/Q1-2025.md) (template) · this document |
+| Each Developer Advocate produces **draft documentation for Core Cardano repositories** | Per-advocate drafts tracked below; submitted for OSC / TSC / TWG review before inclusion on the DevEx site or upstream | [Core Cardano repo documentation](#core-cardano-repository-documentation) |
+
+---
+
+## Meeting cadence
+
+The DevEx WG follows the cadence established in the [Shared DevEx Report to the OSC](../../DevEx-WG-Overview/Q1-2025.md):
+
+| Element | Detail |
+|---------|--------|
+| **Frequency** | Weekly sessions, alternating morning and evening UTC slots to accommodate global time zones |
+| **Format** | Online; recorded when possible; notes and recordings published on the DevEx site |
+| **Planning** | Session plan maintained in the [Developer Experience WG Session Plan spreadsheet](https://docs.google.com/spreadsheets/d/1zJqCgjwqDzZ_4pPb9pODPuFDGt1HujOeQEpmy-OIWEw/edit?gid=0#gid=0) |
+| **Calendar** | [Intersect events calendar](https://calendar.google.com/calendar/u/1?cid=Y19iMGMyODE3NWE2NTBkOGUwNzIwNTM2ZGU4OWE0NDMxMjFiYTcxYTVkMDgxYmRiOWU1NGRiZTU2NjI1NGY5ZGUwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) |
+| **Participation** | Developer Advocates lead; Core Cardano contributors and TWG representatives join as needed |
+
+---
+
+## Q2 2026 session documentation (@danbaruka)
+
+Session documentation authored by [@danbaruka](https://github.com/danbaruka) in Q2 2026, traced from git history on `website/docs/working-group/sessions/q2-2026/`.
+
+| Session | Title | Documented | Commit(s) | Deliverables |
+|---------|-------|------------|-----------|--------------|
+| **16** | UI ↔ Smart Contracts: Wallets, Tx Building, and Submission | 2026-04-30 | [`8c88b3d`](https://github.com/IntersectMBO/developer-experience/commit/8c88b3d), [`bd7b0dd`](https://github.com/IntersectMBO/developer-experience/commit/bd7b0dd) | [Session notes](../../../website/docs/working-group/sessions/q2-2026/16-ui-smart-contract-interaction/session-notes/readme.md) · [Resources](../../../website/docs/working-group/sessions/q2-2026/16-ui-smart-contract-interaction/session-resources/readme.md) · [Recordings](../../../website/docs/working-group/sessions/q2-2026/16-ui-smart-contract-interaction/recordings/readme.md) |
+| **17** | Default Developer Environment for Cardano | 2026-05-28 | [`7c2bf13`](https://github.com/IntersectMBO/developer-experience/commit/7c2bf13) | [Session notes](../../../website/docs/working-group/sessions/q2-2026/17-default-developer-environment/session-notes/readme.md) · [Resources](../../../website/docs/working-group/sessions/q2-2026/17-default-developer-environment/session-resources/readme.md) · [Recordings](../../../website/docs/working-group/sessions/q2-2026/17-default-developer-environment/recordings/readme.md) · [Q2 index update](../../../website/docs/working-group/sessions/q2-2026/index.md) |
+
+### Session 16: UI ↔ Smart Contracts
+
+- **Commit `8c88b3d`**: initial session structure, notes (~210 lines), resources, recordings placeholder, and Q2 session index entry (originally session 15, renumbered when dApp architecture took session 15).
+- **Commit `bd7b0dd`**: renumbered to session 16; updated category, notes, resources, and recordings paths.
+
+**Focus:** CIP-30 wallet flows, transaction lifecycle (build → evaluate → sign → submit → confirm), client-only vs hybrid vs server-custody architectures, and indexer/data-provider trade-offs (Kupo/Ogmios, Blockfrost/Koios/Maestro).
+
+### Session 17: Default Developer Environment for Cardano
+
+- **Commit `7c2bf13`**: full session documentation (notes, resources, recordings placeholder), Q2 session index entry for session 17, and advanced README cross-link for Yaci DevKit.
+
+**Focus:** Working-group debate on the recommended default environment for new Cardano builders: local devnets vs public testnets, hosted providers vs self-hosted nodes, and a graduation path from first setup to mainnet.
+
+---
+
+## OSC reporting schedule
+
+Reports are submitted to the Open Source Committee on a **four-week cycle**. Developer Advocates alternate monthly; each contributes session summaries, onboarding metrics, and documentation progress for inclusion in the common report.
+
+### Reporting rotation
+
+| Month (Q2 2026) | Contributors |
+|-----------------|--------------|
+| April 2026 | All Developer Advocates |
+| May 2026 | All Developer Advocates |
+| June 2026 | All Developer Advocates |
+
+### Common report structure
+
+Each OSC submission should follow the structure in [`../../DevEx-WG-Overview/Q1-2025.md`](../../DevEx-WG-Overview/Q1-2025.md):
+
+1. **Working group overview**: mission, cadence, participants
+2. **Current DevEx status**: high-level assessment (onboarding, documentation, sessions, site)
+3. **Pain points & improvement plan**: link to or excerpt from the common pain-points document
+4. **Sessions & community engagement**: sessions held, recordings, notable onboarding outcomes
+5. **Documentation progress**: Core Cardano repo drafts and site updates
+6. **Next actions**: owners and target dates for the following four-week period
+
+---
+
+## Developer Experience pain points
+
+Pain points affecting the Open Source Strategy are maintained in a **single common document** so OSC receives one coherent view rather than fragmented updates.
+
+**Canonical document:** [`developer-experience-pain-points-and-solutions.md`](developer-experience-pain-points-and-solutions.md)
+
+| Pain point | Priority | Improvement plan (summary) |
+|------------|----------|----------------------------|
+| Fragmented onboarding: no unified roadmap | High | Canonical `getting-started.md` with profile-based tracks |
+| Documentation inconsistency & staleness | Medium | Lightweight doc template; quarterly stale-page audit |
+| Tooling overlap: no opinionated guidance | Medium | Decision guide for SDK / contract-language choice |
+
+The pain-points document consolidates evidence from the [2025 DevEx survey](../Q42025/intersect-developer-experience-survey-2025.md) and the [Q4-2025 Shared DevEx Report](../../DevEx-WG-Overview/Q1-2025.md). Update it when new friction is validated in sessions or survey feedback.
+
+---
+
+## Core Cardano repository documentation
+
+Each Developer Advocate produces **draft documentation** for assigned Core Cardano repositories. Drafts are reviewed by OSC, TSC, and relevant Technical Working Group members before publication on the DevEx site or upstream contribution to the target repo.
+
+Reference list of Core Cardano repositories: [`../../../website/docs/resources/repositories.md`](../../../website/docs/resources/repositories.md)
+
+Existing advanced guides on the DevEx site (e.g. [Haskell Core Contributor](../../../website/docs/how-to-guide/advanced/haskell-core-contributor.md), [Cardano API](../../../website/docs/how-to-guide/advanced/cardano-api.md)) satisfy or partially satisfy Core Cardano documentation needs; additional per-repo drafts are produced by Developer Advocates as assigned.
+
+### Draft documentation standard
+
+Drafts should follow the structure already used in DevEx advanced guides:
+
+- **Objective**: who the doc is for and what they can do after reading it
+- **Prerequisites**: language skills, tooling, prior reading (link to [Cardano Blueprint](https://cardano-scaling.github.io/cardano-blueprint/introduction/index.html) where relevant)
+- **Repository overview**: what the repo governs, how it fits in the stack
+- **First contribution path**: concrete first issue or doc fix, with time estimate
+- **Troubleshooting**: common setup failures
+- **Next steps**: links to formal specs, issues, and related repos
+
+---
+
+## Coordination & resources
+
+| Resource | Purpose | Link |
+|----------|---------|------|
+| DevEx website | Canonical docs and session hub | [devex.intersectmbo.org](https://devex.intersectmbo.org/) |
+| Session plan spreadsheet | Q2 schedule and topic ownership | [Session Plan](https://docs.google.com/spreadsheets/d/1zJqCgjwqDzZ_4pPb9pODPuFDGt1HujOeQEpmy-OIWEw/edit?gid=0#gid=0) |
+| Shared DevEx OSC report (template) | Structure for four-week submissions | [`../../DevEx-WG-Overview/Q1-2025.md`](../../DevEx-WG-Overview/Q1-2025.md) |
+| Pain points & solutions | Common OSC strategy input | [`developer-experience-pain-points-and-solutions.md`](developer-experience-pain-points-and-solutions.md) |
+| Contribution standards | Required for all advocate-produced docs | [`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md) |
+
+---
+
+## Related Q2 2026 deliverables
+
+| Deliverable | Milestone | Document |
+|-------------|-----------|----------|
+| Pain points with proposed solutions | #105 | [`developer-experience-pain-points-and-solutions.md`](developer-experience-pain-points-and-solutions.md) |
+| D&I onboarding guide (Non-English-first developers) | #76 | [`language-inclusive-onboarding-guide.md`](language-inclusive-onboarding-guide.md) |
+
+These feed directly into OSC reporting and the Open Source Strategy pain-points record.
+
+---
+
+*Deliverable: Participate / Lead Developer Experience Working Group: leadership, OSC reporting, and Core Cardano documentation. Completed, Q2 2026.*

--- a/DA Milestones/Dan/Q22026/language-inclusive-onboarding-guide.md
+++ b/DA Milestones/Dan/Q22026/language-inclusive-onboarding-guide.md
@@ -1,24 +1,20 @@
-# Language-Inclusive Onboarding Guide — Cardano Developer Ecosystem
+# Language-Inclusive Onboarding Guide: Cardano Developer Ecosystem
 
-**Milestone:** #76 — D&I Onboarding Guide (Q2 2026)
-**Goal:** Implement diversity and inclusion programs — *draft an onboarding guide tailored for underrepresented groups*
-**Underrepresented group addressed:** developers for whom English is not a first or comfortable working language
-**Author:** Dan Baruka, Developer Advocate — Developer Experience Working Group
+**Milestone:** #76, D&I Onboarding Guide (Q2 2026)
+**Goal:** Implement diversity and inclusion programs: *draft an onboarding guide tailored for underrepresented groups*
+**Underrepresented group addressed:** Non-English-first developers in the Cardano ecosystem
+**Author:** Dan Baruka, Developer Advocate, Developer Experience Working Group
 **Status:** Draft for review
-
----
 
 ## Executive summary
 
-A significant share of capable developers never complete their first contribution to Cardano — not for lack of technical ability, but because the standard onboarding path is in English and silently assumes English-language fluency at every step: docs, tooling output, issue threads, community channels, and live sessions. Developers whose first language is not English routinely report that the *first* friction they hit is linguistic, not technical.
+A significant share of capable developers never complete their first contribution to Cardano, not for lack of technical ability, but because the standard onboarding path is in English and silently assumes English-language fluency at every step: docs, tooling output, issue threads, community channels, and live sessions. Non-English-first developers routinely report that the *first* friction they hit is linguistic, not technical.
 
 This guide proposes a **language-inclusive onboarding framework** that the Developer Experience Working Group (DevEx WG) can adopt across its documentation, sessions, and advocacy program. It does not replace the general getting-started guide; it removes the implicit fluency requirement, lowers the cost of asking the first question, and treats non-English contributions (translation, glossaries, localized guides) as first-class work.
 
 The framework is language-agnostic. The Francophone outreach the program already runs (notably West/Central Africa) is used as a worked example, but the same pattern applies to Spanish, Portuguese, Arabic, Mandarin, Hindi, Swahili, and any other language where Cardano onboarding material is thin.
 
-> **Note on scope:** the milestone calls for an onboarding guide for an "underrepresented group". Several dimensions of underrepresentation exist (gender, geography, background, career stage, accessibility). This deliverable focuses exclusively on the **language dimension**, because it is the most universal first-step barrier and the one where the program already has active outreach to learn from. Other dimensions should be addressed in separate, focused guides rather than diluted into a single document.
-
----
+> **Note on scope:** the milestone calls for an onboarding guide for an "underrepresented group". Several dimensions of underrepresentation exist (gender, geography, background, career stage, accessibility). This deliverable focuses exclusively on **Non-English-first developers**, because language is a universal first-step barrier and the program already has active outreach to learn from. Other dimensions should be addressed in separate, focused guides rather than diluted into a single document.
 
 ## Evidence base
 
@@ -26,12 +22,11 @@ This guide consolidates findings the program has already produced and the standa
 
 | Source | What it provides | Location |
 |--------|------------------|----------|
-| Intersect Developer Experience Survey — 2025 | Self-reported language needs, regional distribution of respondents | [`../Q42025/intersect-developer-experience-survey-2025.md`](../Q42025/intersect-developer-experience-survey-2025.md) |
-| Shared DevEx Report to the OSC (Q4-2025) | "Current DevEx Status" — onboarding rated High priority / Needs Improvement | [`../../DevEx-WG-Overview/Q1-2025.md`](../../DevEx-WG-Overview/Q1-2025.md) |
-| DevEx getting-started guide | Current canonical onboarding entry point (English) | [`../../../website/docs/getting-started.md`](../../../website/docs/getting-started.md) |
+| Intersect Developer Experience Survey 2025 | Self-reported language needs, regional distribution of respondents | [`../Q42025/intersect-developer-experience-survey-2025.md`](../Q42025/intersect-developer-experience-survey-2025.md) |
+| Shared DevEx Report to the OSC (Q4-2025) | "Current DevEx Status": onboarding rated High priority / Needs Improvement | [`../../DevEx-WG-Overview/Q1-2025.md`](../../DevEx-WG-Overview/Q1-2025.md) |
+| DevEx pain points report (Q2 2026) | Fragmented onboarding affects all newcomers, including Non-English-first developers | [`developer-experience-pain-points-and-solutions.md`](developer-experience-pain-points-and-solutions.md) |
+| DevEx getting-started guide | Current canonical onboarding entry point | [`../../../website/docs/getting-started.md`](../../../website/docs/getting-started.md) |
 | Contribution & conduct standards | Required reading for any contributor path proposed here | [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) · [`CODE-OF-CONDUCT.md`](../../../CODE-OF-CONDUCT.md) |
-
----
 
 ## Where the language barrier actually bites
 
@@ -40,66 +35,62 @@ The "language barrier" is not a single problem. It shows up as four distinct fri
 | Friction | What it looks like | Why it blocks contribution |
 |----------|--------------------|----------------------------|
 | **Reading technical English** | Newcomer can follow code samples but struggles with prose-heavy docs and long issue threads. | Slows progress; usually surmountable with translation tools. |
-| **Writing public English** | Newcomer can read a doc but is reluctant to open an issue or PR description in English. | Highest-impact blocker — it stops the *first* visible contribution. |
+| **Writing public English** | Newcomer can read a doc but is reluctant to open an issue or PR description in English. | Highest-impact blocker: it stops the *first* visible contribution. |
 | **Technical jargon and ecosystem-specific terms** | Generic translators mishandle terms like *epoch*, *UTxO*, *delegation*, *native asset*. | Even strong English readers misread or mistranslate Cardano-specific content. |
 | **Live spoken English** | Working-group calls and recorded sessions run in English, often without transcripts or captions. | Excludes contributors who read English comfortably but cannot follow spoken English in real time. |
 
 Each section of the framework below targets one of these frictions.
 
----
-
 ## Language-inclusive onboarding framework
 
-### 1. Reading — make the existing docs usable in any language
+### 1. Reading: make the existing docs usable in any language
 
-**Principle:** A non-English-first developer should be able to read every canonical onboarding page in their language with one click and have confidence the translation is correct on the technical terms.
+**Principle:** A Non-English-first developer should be able to read every canonical onboarding page in their language with one click and have confidence the translation is correct on the technical terms.
 
 **For the newcomer:**
 - Use browser translation for prose; cross-check code samples against the original page (code is the source of truth).
-- When a translation looks wrong, that is itself a documentation bug — open an issue.
+- When a translation looks wrong, that is itself a documentation bug; open an issue.
 
 **For the program:**
 - Publish a short, maintained glossary of Cardano terms in the DevEx repo, with entries in the languages the program actively supports. This single artifact disproportionately improves the quality of every machine-translated page.
 - Mark pages that are translation-safe (no ambiguous idioms, no untranslated jargon) so contributors translating them know they will not need to rewrite English first.
 
-### 2. Writing — lower the cost of the first public message
+### 2. Writing: lower the cost of the first public message
 
 **Principle:** Imperfect English is welcome, normal, and explicitly accommodated. The community absorbs it without issue.
 
 **For the newcomer:**
-- Draft issues and PR descriptions in your first language, then translate. State plainly that English is not your first language — this is well-received and routine.
+- Draft issues and PR descriptions in your first language, then translate. State plainly that English is not your first language. This is well-received and routine.
 - Keep PR descriptions short and structured (what / why / how tested); short English is easier to write correctly than long English.
 - Treat translation, terminology fixes, and clarifying documentation as first-class contributions; they are explicitly welcomed in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md).
 
 **For the program:**
 - Provide ready-to-use issue and PR templates with neutral, simple English phrasing.
-- Maintain a public norm that reviewers will not nitpick grammar on PRs flagged as written by a non-English-first contributor — feedback on language goes in a separate, optional thread.
+- Maintain a public norm that reviewers will not nitpick grammar on PRs flagged as written by a Non-English-first contributor. Feedback on language goes in a separate, optional thread.
 
-### 3. Jargon — handle Cardano-specific terms explicitly
+### 3. Jargon: handle Cardano-specific terms explicitly
 
 **Principle:** Ecosystem-specific vocabulary is the part machine translation gets wrong most often. Owning it locally is cheap.
 
 **For the newcomer:**
-- When reading a translated page, treat protocol terms (epoch, slot, UTxO, native asset, delegation, governance action) as English keywords — do not rely on a translator's guess.
+- When reading a translated page, treat protocol terms (epoch, slot, UTxO, native asset, delegation, governance action) as English keywords. Do not rely on a translator's guess.
 - If you cannot find a glossary entry for a term, open an issue requesting one. This *is* a contribution.
 
 **For the program:**
-- Curate a single canonical glossary of ~50–100 core terms with short, plain-language explanations, then translate that glossary first (rather than translating every page).
+- Curate a single canonical glossary of ~50-100 core terms with short, plain-language explanations, then translate that glossary first (rather than translating every page).
 - Link the glossary from `getting-started.md` and from every page that uses domain terms heavily.
 
-### 4. Spoken English — make live sessions usable asynchronously
+### 4. Spoken English: make live sessions usable asynchronously
 
 **Principle:** Sessions are an onboarding asset only if they are usable by contributors who cannot follow spoken English in real time.
 
 **For the newcomer:**
-- Prefer the recording over the live call — pause, rewind, run through a translator. Live attendance is optional.
+- Prefer the recording over the live call: pause, rewind, run through a translator. Live attendance is optional.
 - Ask questions on [GitHub Discussions](https://github.com/IntersectMBO/developer-experience/discussions) or in the DevEx Discord channel afterward, in writing.
 
 **For the program:**
 - Continue publishing session recordings; add at least auto-generated captions and, where possible, a short written summary of each session in the DevEx site.
 - Encourage Developer Advocates fluent in additional languages to host periodic sessions in those languages and publish recordings with transcripts.
-
----
 
 ## Standard contribution path (unchanged by language)
 
@@ -107,25 +98,21 @@ Once the language friction is removed, the technical path is the same as for any
 
 | Path | Best for | Starting point |
 |------|----------|----------------|
-| **A — Smart contracts** | Developers comfortable with typed/functional languages | Aiken on testnet — [aiken-lang.org](https://aiken-lang.org) |
-| **B — dApp / front-end** | JavaScript/TypeScript developers | Mesh, Lucid/Evolution, or Blaze SDKs |
-| **C — Documentation / translation** | Anyone — the most direct on-ramp for non-English-first contributors | Issues labeled `documentation`, `translation`, or `good first issue` |
-| **D — Infrastructure / tooling** | Experienced systems engineers | Ecosystem repos under [github.com/IntersectMBO](https://github.com/IntersectMBO) |
+| **A: Smart contracts** | Developers comfortable with typed/functional languages | Aiken on testnet: [aiken-lang.org](https://aiken-lang.org) |
+| **B: dApp / front-end** | JavaScript/TypeScript developers | Mesh, Lucid/Evolution, or Blaze SDKs |
+| **C: Documentation / translation** | Anyone: the most direct on-ramp for Non-English-first contributors | Issues labeled `documentation`, `translation`, or `good first issue` |
+| **D: Infrastructure / tooling** | Experienced systems engineers | Ecosystem repos under [github.com/IntersectMBO](https://github.com/IntersectMBO) |
 
-Canonical reference for all four: the [Cardano Developer Portal](https://developers.cardano.org). Standard flow: fork → clone → branch → commit → push → pull request, with scope discussed in an issue first — see [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) and the [Code of Conduct](../../../CODE-OF-CONDUCT.md).
-
----
+Canonical reference for all four: the [Cardano Developer Portal](https://developers.cardano.org). Standard flow: fork → clone → branch → commit → push → pull request, with scope discussed in an issue first. See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) and the [Code of Conduct](../../../CODE-OF-CONDUCT.md).
 
 ## Onboarding checklist
 
 - [ ] Read the DevEx [getting-started guide](../../../website/docs/getting-started.md) using your preferred translation tool; bookmark the original page.
 - [ ] Install Git, a recent Node.js (LTS), and an editor; confirm you can run a fork → PR cycle on a throwaway repo.
 - [ ] Pick **one** technical path (A / B / C / D) and one first step inside it.
-- [ ] Join the DevEx WG Discord channel and introduce yourself in your preferred language — note that English is not your first language if helpful.
+- [ ] Join the DevEx WG Discord channel and introduce yourself in your preferred language. Note that English is not your first language if helpful.
 - [ ] Find or open an issue, agree on scope in the issue thread, then submit a small first PR.
-- [ ] Book a 1:1 with a Developer Advocate — ideally one who speaks your language — if you are blocked for more than a day.
-
----
+- [ ] Book a 1:1 with a Developer Advocate, ideally one who speaks your language, if you are blocked for more than a day.
 
 ## Community and mentorship
 
@@ -133,44 +120,44 @@ Canonical reference for all four: the [Cardano Developer Portal](https://develop
 |---------|---------|------|
 | DevEx WG Discord | Day-to-day help, async questions | [Dev-Ex WG channel](https://discord.com/channels/1136727663583698984/1250047836339306526) |
 | GitHub Discussions | Long-form questions, decisions | [developer-experience discussions](https://github.com/IntersectMBO/developer-experience/discussions) |
-| Sessions calendar | Live working-group sessions (recorded) | [Intersect events calendar](https://calendar.google.com/calendar/u/1?cid=Y19iMGMyODE3NWE2NTBkOGUwNzIwNTM2ZGU4OWE0NDMxMjFiYTcxYTVkMDgxYmRiOWU1NGRiZTU2NjI1NGY5ZGUwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) |
+| Sessions calendar | Live working-group sessions (recorded) | [Intersect events calendar](https://calendar.google.com/calendar/u/1?cid=Y19iMGMyODE3NWE2NTBkOGUwNzIwNTM2ZGU4OWE0NDMxMjFiYTcxYTVkMDgxYmRiOWU1NGRiZTU2NjI1NGY5ZGUwQGdyb3VwLmNhbGVuZGFyLmdvb2dnZS5jb20) |
 | Cardano Forum | Ecosystem-wide discussion | [forum.cardano.org](https://forum.cardano.org) |
 | Cardano Stack Exchange | Technical Q&A | [cardano.stackexchange.com](https://cardano.stackexchange.com) |
 
-Developer Advocates are the program's primary mentorship channel. The advocates roster, working languages, and booking links are published on the DevEx site so this document remains independent of personnel changes. Intersect membership (~USD 10 / year) unlocks Discord and governance participation but is **not** required to contribute code or documentation — [members.intersectmbo.org/registration](https://members.intersectmbo.org/registration) · [membership guide](../../../website/docs/intersect-membership-guide.md).
+Developer Advocates are the program's primary mentorship channel. The advocates roster, working languages, and booking links are published on the DevEx site so this document remains independent of personnel changes. Intersect membership (~USD 10 / year) unlocks Discord and governance participation but is **not** required to contribute code or documentation: [members.intersectmbo.org/registration](https://members.intersectmbo.org/registration) · [membership guide](../../../website/docs/intersect-membership-guide.md).
 
----
+## Implementation roadmap
 
-## Implementation roadmap (Q2–Q3 2026)
-
-| Phase | Deliverable | Owner |
-|-------|-------------|-------|
-| Q2 2026 | Publish this guide on the DevEx site; cross-link from `getting-started.md` and `CONTRIBUTING.md`. | DevEx WG |
-| Q2 2026 | Ship a first-pass Cardano glossary (~50 terms) in English; structure it for translation. | DevEx WG + advocates |
-| Q3 2026 | Translate the glossary into the first non-English language with active outreach (French as the pilot). | Volunteer translators |
-| Q3 2026 | Establish a public advocates list showing working languages and time zones. | Developer Advocate team |
-| Q3 2026 | Pilot a localized session in at least one non-English language; publish recording, captions, and short written summary. | Volunteer advocates |
-| Q3 2026 | Add captions or written summaries to all DevEx WG session recordings. | Session hosts |
-
----
+| Date | Deliverable | Owner |
+|------|-------------|-------|
+| TBD | Publish this guide on the DevEx site; cross-link from `getting-started.md` and `CONTRIBUTING.md`. | DevEx WG |
+| TBD | Ship a first-pass Cardano glossary (~50 terms) in English; structure it for translation. | DevEx WG + advocates |
+| TBD | Translate the glossary into the first non-English language with active outreach (French as the pilot). | Volunteer translators |
+| TBD | Establish a public advocates list showing working languages and time zones. | Developer Advocate team |
+| TBD | Pilot a localized session in at least one non-English language; publish recording, captions, and short written summary. | Volunteer advocates |
+| TBD | Add captions or written summaries to all DevEx WG session recordings. | Session hosts |
 
 ## Success indicators
 
 The guide should be evaluated, not assumed effective. Suggested indicators, all measurable from existing signals:
 
-- Time from first contact to merged first PR for contributors whose first language is not English.
+- Time from first contact to merged first PR for Non-English-first contributors.
 - Share of first-time contributors who report (in the annual survey) that language friction was a blocker.
 - Number of translation, glossary, or documentation-clarification contributions merged per quarter.
-- Retention: share of first-time non-English-first contributors who submit a second PR within 90 days.
+- Retention: share of first-time Non-English-first contributors who submit a second PR within 90 days.
 
 A baseline should be captured before the guide is promoted, so changes are attributable.
 
----
+## Relationship to other D&I work
+
+This guide complements, not replaces, other inclusion efforts in the ecosystem:
+
+- **Women-in-tech onboarding** addresses gender-specific barriers in a separate focused guide.
+- **Regional D&I outreach** (e.g. Cardano Africa Tech Summit fireside sessions) addresses geography and emerging-market context.
+- **Localized educational resources** (e.g. French-language workshops and translated articles) put this framework into practice.
 
 ## Localization of this guide
 
 This document is published in English as the working language of the DevEx WG and OSC review. Localized versions should be produced as separate pages in the same repo under `website/docs/i18n/`, kept in sync via a lightweight diff process rather than maintained as forks. French is the natural pilot translation given existing Francophone outreach; Spanish and Portuguese are reasonable next candidates. Translation contributions are explicitly welcomed.
 
----
-
-*Deliverable: Milestone #76 — D&I onboarding guide for developers facing a language barrier in the Cardano ecosystem. Draft — Q2 2026.*
+*Deliverable: Milestone #76, D&I onboarding guide for Non-English-first developers in the Cardano ecosystem. Draft, Q2 2026.*

--- a/DA Milestones/Dan/Q22026/strategic-collaboration-log.md
+++ b/DA Milestones/Dan/Q22026/strategic-collaboration-log.md
@@ -1,0 +1,76 @@
+# Strategic Collaboration Log: Q2 2026
+
+**Milestone:** Deepen Strategic Collaborations (Q2 2026)
+**Goal:** Document outcomes in a Strategic Collaboration Log (who was contacted, response, next steps)
+**Author:** Dan Baruka, Developer Advocate, Developer Experience Working Group
+**Status:** Completed
+
+## Executive summary
+
+Two strategic collaborations were advanced in Q2 2026: a completed documentation collaboration between the Blaze SDK and Yaci Store teams, and an ongoing partnership between WADA and Zedeal Group Hub Ltd to support African hub projects with technical mentorship.
+
+---
+
+## Collaboration 1: Blaze SDK and Yaci Store / Yaci DevKit
+
+| Field | Detail |
+|-------|--------|
+| **Who was contacted** | Blaze SDK team, Yaci Store / Yaci DevKit team (BloxBean) |
+| **How contact was made** | Introductory collaboration facilitated by Developer Advocate; teams connected via Discord group |
+| **Scope agreed** | Documentation-only: explore using Yaci Store as a local Blockfrost-compatible indexer with Blaze SDK (no code changes required if Blaze's Blockfrost backend is compatible) |
+| **Response** | Both teams agreed to joint review of a shared integration guide for the Developer Experience portal |
+| **Outcome** | Draft integration guide authored and merged on the DevEx site |
+| **Status** | Completed |
+
+### Deliverable
+
+- **PR:** [Add Blaze SDK + Yaci Store integration guide (#186)](https://github.com/IntersectMBO/developer-experience/pull/186) (merged 2026-05-18)
+- **Published guide:** [Blaze + Yaci Store integration](../../../website/docs/guides/blaze-yaci-store-integration.md)
+- **Live URL:** https://devex.intersectmbo.org/docs/guides/blaze-yaci-store-integration
+
+The guide covers architecture, configuration, data flow, advantages, limitations, and references to Blaze and Yaci DevKit documentation.
+
+### Next steps
+
+- Monitor community feedback on the guide via GitHub issues and DevEx Discord
+- Update the guide if Blaze SDK or Yaci Store API surfaces change
+- Consider a follow-up DevEx WG session demo using the documented setup
+
+---
+
+## Collaboration 2: WADA and Zedeal Group Hub Ltd
+
+| Field | Detail |
+|-------|--------|
+| **Who was contacted** | [WADA.org](https://wada.org), Zedeal Group Hub Ltd |
+| **How contact was made** | Developer Advocate-facilitated introduction and follow-up discussions |
+| **Scope proposed** | Technical Support and Mentorship Program for projects emerging from African hubs |
+| **Response** | Zedeal proposed a technical follow-up framework so early-stage projects can request support on blockchain integrations, smart contract implementation, SDK usage, infrastructure, and development architecture |
+| **Outcome** | Partnership framework under development; aligns Cardano ecosystem projects with structured technical support and mentorship |
+| **Status** | In progress |
+
+### Program focus
+
+- Support for projects emerging from African developer hubs
+- Technical follow-up on: blockchain integrations, smart contracts, SDK usage, infrastructure, development architecture
+- Mentorship pathway connecting hub projects to Cardano ecosystem resources and Developer Advocate support
+
+### Next steps
+
+- Finalize the Technical Support and Mentorship Program structure with WADA and Zedeal
+- Define intake process for hub projects requesting support
+- Publish program details and contact path for eligible projects
+- Track first mentorship engagements and report outcomes in Q3 2026 OSC update
+
+---
+
+## Summary
+
+| Collaboration | Parties | Status | Key deliverable |
+|---------------|---------|--------|-----------------|
+| Blaze + Yaci Store integration | Blaze SDK team, Yaci Store / Yaci DevKit team | Completed | [PR #186](https://github.com/IntersectMBO/developer-experience/pull/186), [integration guide](https://devex.intersectmbo.org/docs/guides/blaze-yaci-store-integration) |
+| African hub technical mentorship | WADA.org, Zedeal Group Hub Ltd | In progress | Technical Support and Mentorship Program (framework under development) |
+
+---
+
+*Deliverable: Strategic Collaboration Log, Q2 2026.*


### PR DESCRIPTION
Adds the **Language-Inclusive Onboarding Guide** for Non-English-first developers in the Cardano ecosystem (Milestone #76, Q2 2026).

The guide addresses a common first-step blocker: onboarding assumes English fluency across docs, tooling, issue threads, community channels, and live sessions. It proposes a language-inclusive framework the DevEx WG can adopt without replacing the existing getting-started path.

Key sections:
- **Evidence base** — ties the guide to the 2025 DevEx survey, OSC report, pain-points analysis, and existing repo standards
- **Four language frictions** — reading, writing, jargon, and spoken English, each with concrete remedies
- **Language-inclusive framework** — actionable guidance for newcomers and the program (glossary-first approach, translation-safe docs, PR/issue norms, async session access)
- **Standard contribution paths** — smart contracts, dApp/front-end, documentation/translation, and infrastructure
- **Onboarding checklist, community channels, and mentorship** — practical next steps for newcomers
- **Implementation roadmap** — glossary, localized sessions, captions, advocates roster, site publication
- **Success indicators** — measurable outcomes (time to first PR, retention, translation contributions)

Francophone outreach (West/Central Africa) is used as a worked example; the framework is language-agnostic and applies to Spanish, Portuguese, Arabic, Mandarin, Hindi, Swahili, and others.

## Test plan

- [ ] Review scope: guide focuses on Non-English-first developers only (not a catch-all D&I doc)
- [ ] Verify internal links resolve (`getting-started.md`, `CONTRIBUTING.md`, survey/pain-points docs)
- [ ] Confirm alignment with Milestone #76 deliverable requirements
- [ ] Check roadmap items are actionable and owned by the right teams
- [ ] Validate onboarding checklist and contribution paths match current DevEx site content