### PR TITLE
docs: refactor README for better developer onboarding (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,199 @@
-# Welcome to the Intersect MBO Developer Experience Working Group
+# Intersect MBO Developer Experience
 
-## Our Mission
-We are a community of `Developer Advocates` from `IntersectMBO` focused on enhancing the developer experience within the Cardano ecosystem. Our goal is to identify, address, and improve key aspects of the development process to make building on Cardano more accessible, efficient, and rewarding. 
+<p align="center">
+  <a href="https://github.com/IntersectMBO/developer-experience/stargazers"><img src="https://img.shields.io/github/stars/IntersectMBO/developer-experience?style=flat-square&logo=github&label=Stars&color=24292f" alt="GitHub stars"></a>
+  <a href="https://github.com/IntersectMBO/developer-experience/network/members"><img src="https://img.shields.io/github/forks/IntersectMBO/developer-experience?style=flat-square&logo=github&label=Forks&color=24292f" alt="GitHub forks"></a>
+  <a href="https://github.com/IntersectMBO/developer-experience/issues"><img src="https://img.shields.io/github/issues/IntersectMBO/developer-experience?style=flat-square&logo=github&label=Issues&color=24292f" alt="Open issues"></a>
+  <a href="https://github.com/IntersectMBO/developer-experience/graphs/contributors"><img src="https://img.shields.io/github/contributors/IntersectMBO/developer-experience?style=flat-square&logo=github&label=Contributors&color=24292f" alt="Contributors"></a>
+</p>
 
-Learn more about our initiatives and resources at our website: [Intersect MBO Developers Experience Website](devex.intersectmbo.org/)
+<p align="center">
+  <a href="https://devex.intersectmbo.org"><img src="https://img.shields.io/badge/Website-devex.intersectmbo.org-0033AD?style=flat-square&logo=cardano&logoColor=white" alt="Developer Experience website"></a>
+  <a href="https://github.com/IntersectMBO/developer-experience/actions/workflows/deploy.yml"><img src="https://img.shields.io/github/actions/workflow/status/IntersectMBO/developer-experience/deploy.yml?branch=main&style=flat-square&label=Deploy&logo=githubactions&logoColor=white" alt="Deploy status"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-009688?style=flat-square&logo=apache&logoColor=white" alt="Apache 2.0 License"></a>
+  <a href="website/package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D20-339933?style=flat-square&logo=nodedotjs&logoColor=white" alt="Node.js 20+"></a>
+  <a href="website/package.json"><img src="https://img.shields.io/badge/Docusaurus-3.10-2ECC71?style=flat-square&logo=docusaurus&logoColor=white" alt="Docusaurus"></a>
+</p>
 
+Documentation, guides, and working-group resources for developers building on [Cardano](https://cardano.org/). This repository powers the [Developer Experience portal](https://devex.intersectmbo.org) and hosts session materials for the Intersect MBO Developer Experience Working Group.
 
-## What We Do
+## Overview
 
-- Identify and prioritize developer experience issues in the Cardano ecosystem.
-- Propose and implement solutions to improve tooling, documentation, and workflows.
-- Foster collaboration between developers, projects, and stakeholders.
-- Support multi-language integration.
-- Develop and workshop a Developer Thriving Framework to address social barriers and improve community engagement.
-- Focus on the human component of developer experience, beyond just documentation and technology.
-- Organize collaborative workshops to gather diverse perspectives and create shared understanding.
-- Address pain points and obstacles that hinder newcomer involvement and growth.
-- Build trust and break down silos within the developer community.
+The **Developer Experience (DevEx) Working Group** is a community of Developer Advocates from [Intersect MBO](https://www.intersectmbo.org/) focused on making Cardano more accessible, efficient, and rewarding to build on.
 
-## Key Focus Areas
-- **Onboarding and Documentation**
-- **Tooling and Development Workflows**
-- **Collaboration with other developers in the ecosystem**
-- **Collecting feedback from developers**
-- **Community Support and Knowledge Sharing**
+We identify pain points in the ecosystem, improve tooling and documentation, and run collaborative workshops for developers at every level.
 
-## How to Get Involved
-- **Meetings**: Join our weekly Developer experience working group sessions by subscribing to the [Intersect Event calendar](https://calendar.google.com/calendar/u/1?cid=Y19iMGMyODE3NWE2NTBkOGUwNzIwNTM2ZGU4OWE0NDMxMjFiYTcxYTVkMDgxYmRiOWU1NGRiZTU2NjI1NGY5ZGUwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
-- **GitHub**: Most discussions will happen in Github [issues](https://github.com/IntersectMBO/developer-experience/issues)  and [pull requests](https://github.com/IntersectMBO/developer-experience/pulls). Issues are the problems faced by the Cardano Developer community and PR's propose solutions. Participate in [discussions](https://github.com/IntersectMBO/developer-experience/discussions/) and contribute to projects
-- Join **Intersect**: [Become a Member](https://members.intersectmbo.org/registration)
-- **Discord**: [Dev-Ex WG](https://discord.com/channels/1136727663583698984/1250047836339306526)
-- **Share Feedback**: Share your feedback on our discord and help us improve the ecosystem.
+**Key focus areas:**
+
+| Area | What we work on |
+| --- | --- |
+| Onboarding & documentation | Guides, tutorials, and structured learning paths |
+| Tooling & workflows | Dev environments, SDKs, and developer tooling |
+| Community & collaboration | Working-group sessions, feedback loops, knowledge sharing |
+| Inclusive onboarding | Multi-language support and the Developer Thriving Framework |
+
+**Live site:** [devex.intersectmbo.org](https://devex.intersectmbo.org)
 
 ## Developer Advocates
-Meet and connect with our past and present developer advocates:
-- **Current Cohort**:
-   - [Uche](https://www.linkedin.com/in/thisisobate)
-     - Schedule a call with Uche [here](https://calendar.app.google/6HC9yHfTHrQ1dfcB9)
-     - Discord: @obate.
-   - [Emmanuel](https://www.linkedin.com/in/emmanuel-shikuku-devops/)
-     - X (Twitter): [@Emmanuel_tyty](https://x.com/Emmanuel_tyty)
-     - Discord: @emmanueltyty
-     - Schedule a call with Emmanuel [here](https://calendar.app.google/3LGaFshgi7q9fsQD8)
-   - [Dan](https://www.linkedin.com/in/danbaruka/)
-     - X (Twitter): [@danamphred](https://x.com/danamphred)
-     - Discord: @danamphred
-     - Schedule a call with Dan [here](https://calendar.app.google/T1BuH5EnRDyMTsyV8)
-   - [Harun](https://www.linkedin.com/in/harunslinked/)
-     - Discord: @wesh09
-     - Schedule a call with Harun [here](https://calendly.com/harunm28/30min)
-- **Past Cohort**:
-   1. **Alex**  
-      - **Interview** : [Watch now](https://www.youtube.com/watch?v=U-cGNG3rzPg)  
-      - **LinkedIn**  : [Alex's LinkedIn](https://www.linkedin.com/in/alex-seregin/)  
-      - **Discord**   : alexeusgr
 
-   2. **Bernand**  
-      - **Interview** : [Watch now](https://www.youtube.com/watch?v=grbX5DAaW5Q)  
-      - **LinkedIn**  : [Bernand's LinkedIn](https://www.linkedin.com/in/bernard-sibanda-954563243/)  
-      - **Discord**   : wims5274
+Connect with the current cohort for mentorship, session planning, or contribution guidance.
 
-   3. **Suganya**  
-      - **Interview** : [Watch now](https://www.youtube.com/watch?v=o8a6gTcE50w)  
-      - **LinkedIn**  : [Suganya's LinkedIn](https://www.linkedin.com/in/suganya-raju/)  
-      - **Discord**   : suganya1607
+### Current Cohort
 
-   4. **Udai**  
-      - **Interview** : [Watch now](https://www.youtube.com/watch?v=UDXshRpVA6M)  
-      - **LinkedIn**  : [Udai's LinkedIn](https://www.linkedin.com/in/solanki/)  
-      - **Discord**   : thecoder0001
-## Contact & Communication
+| Advocate | Links | Schedule a call |
+| --- | --- | --- |
+| **Uche** | [LinkedIn](https://www.linkedin.com/in/thisisobate) · Discord: `@obate` | [Book a call](https://calendar.app.google/6HC9yHfTHrQ1dfcB9) |
+| **Emmanuel** | [LinkedIn](https://www.linkedin.com/in/emmanuel-shikuku-devops/) · [X](https://x.com/Emmanuel_tyty) · Discord: `@emmanueltyty` | [Book a call](https://calendar.app.google/3LGaFshgi7q9fsQD8) |
+| **Dan** | [LinkedIn](https://www.linkedin.com/in/danbaruka/) · [X](https://x.com/danamphred) · Discord: `@danamphred` | [Book a call](https://calendar.app.google/T1BuH5EnRDyMTsyV8) |
+| **Harun** | [LinkedIn](https://www.linkedin.com/in/harunslinked/) · Discord: `@wesh09` | [Book a call](https://calendly.com/harunm28/30min) |
 
-- **GitHub Discussions**: [Developer-Experience Working Group Repository](https://github.com/IntersectMBO/developer-experience/discussions)
-- **Discord Channel**: [OSC- Working Groups](https://discord.com/channels/1136727663583698984/1239886460266479696)
-- **Email**: [Open Source Office](oso@intersectmbo.org)
+### Past Cohort
 
-## Contributing Guidelines
-- Please checkout our [Contributing Documentation](./CONTRIBUTING.md).
-- Read our Code of Conduct. 
-- Check existing issues before creating new ones.
-- Provide clear, detailed descriptions.
-- Follow our template in `CONTRIBUTING.md` for issues and pull requests.
-- Be respectful and constructive.
+| Advocate | Interview | LinkedIn | Discord |
+| --- | --- | --- | --- |
+| Alex | [Watch](https://www.youtube.com/watch?v=U-cGNG3rzPg) | [Profile](https://www.linkedin.com/in/alex-seregin/) | `alexeusgr` |
+| Bernand | [Watch](https://www.youtube.com/watch?v=grbX5DAaW5Q) | [Profile](https://www.linkedin.com/in/bernard-sibanda-954563243/) | `wims5274` |
+| Suganya | [Watch](https://www.youtube.com/watch?v=o8a6gTcE50w) | [Profile](https://www.linkedin.com/in/suganya-raju/) | `suganya1607` |
+| Udai | [Watch](https://www.youtube.com/watch?v=UDXshRpVA6M) | [Profile](https://www.linkedin.com/in/solanki/) | `thecoder0001` |
+
+## Quick Start
+
+Get the documentation site running locally in under 5 minutes:
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/IntersectMBO/developer-experience.git
+cd developer-experience/website
+
+# 2. Install dependencies (Node.js 20+ required)
+npm install
+
+# 3. Start the development server with hot reload
+npm run start:dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser. Edits to files under `website/docs/` reload automatically.
+
+## Installation and Setup
+
+### Prerequisites
+
+| Requirement | Version |
+| --- | --- |
+| [Node.js](https://nodejs.org/) | 20 or higher |
+| npm | Bundled with Node.js |
+| Git | Any recent version |
+
+### Step-by-step setup
+
+See the [Contributing Guide](./CONTRIBUTING.md) for full setup, development, and submission instructions.
+
+## Usage
+
+### Edit documentation
+
+Documentation lives in `website/docs/`. Create or edit Markdown (`.md`) or MDX (`.mdx`) files:
+
+```markdown
+---
+sidebar_position: 2
+---
+
+# My New Guide
+
+Brief introduction for developers.
+
+## Prerequisites
+
+- A Cardano wallet
+- Node.js 20+
+
+## Steps
+
+1. Install the CLI tool.
+2. Run your first command.
+```
+
+### Add a working-group session
+
+Session materials follow a quarter-based layout under `website/docs/working-group/sessions/`:
+
+```
+website/docs/working-group/sessions/
+└── q2-2026/
+    └── 18-my-session/
+        ├── _category_.json
+        ├── session-notes/
+        │   └── readme.md
+        └── session-resources/
+            └── readme.md
+```
+
+See existing sessions (for example `q4-2025/01-kickoff-orientation/`) for the established pattern.
+
+## Project Structure
+
+```
+developer-experience/
+├── website/                    # Docusaurus documentation site
+│   ├── docs/                   # Documentation content (Markdown / MDX)
+│   │   ├── getting-started.md  # Main onboarding guide
+│   │   ├── how-to-guide/       # Beginner, intermediate, and advanced guides
+│   │   ├── tutorials/          # Hands-on tutorials
+│   │   ├── resources/          # Tools, repos, and community links
+│   │   └── working-group/      # DevEx WG session materials
+│   ├── src/                    # React components and custom theme
+│   ├── static/                 # Static assets (images, CNAME)
+│   └── docusaurus.config.ts    # Site configuration
+├── DA Milestones/              # Developer Advocate milestone reports
+├── scripts/                    # Utility scripts (e.g. changelog)
+├── CONTRIBUTING.md             # Contribution guidelines
+├── CODE-OF-CONDUCT.md          # Community standards
+└── LICENSE                     # Apache 2.0
+```
+
+## Documentation
+
+| Resource | Description |
+| --- | --- |
+| [Getting Started](website/docs/getting-started.md) | Onboarding paths for new Cardano developers |
+| [How-To Guides](website/docs/how-to-guide/) | Step-by-step guides by skill level |
+| [Working Group](website/docs/working-group/readme.md) | Session plans, notes, and recordings |
+| [FAQ](website/docs/faq.md) | Answers to common questions |
+| [Intersect Membership Guide](website/docs/intersect-membership-guide.md) | How to join Intersect and access Discord |
+
+## Get Involved
+
+- **Meetings** — Join weekly DevEx working-group sessions via the [Intersect Event calendar](https://calendar.google.com/calendar/u/1?cid=Y19iMGMyODE3NWE2NTBkOGUwNzIwNTM2ZGU4OWE0NDMxMjFiYTcxYTVkMDgxYmRiOWU1NGRiZTU2NjI1NGY5ZGUwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
+- **GitHub** — Report problems in [Issues](https://github.com/IntersectMBO/developer-experience/issues), propose fixes in [Pull Requests](https://github.com/IntersectMBO/developer-experience/pulls), and join [Discussions](https://github.com/IntersectMBO/developer-experience/discussions).
+- **Intersect membership** — [Become a member](https://members.intersectmbo.org/registration) to participate in governance and access the Discord community.
+- **Discord** — DevEx WG channel: [#developer-experience](https://discord.com/channels/1136727663583698984/1250047836339306526).
+
+## Contributing
+
+We welcome contributions from all skill levels. Before you start:
+
+1. Read [CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow.
+2. Review the [Code of Conduct](./CODE-OF-CONDUCT.md).
+3. Check [existing issues](https://github.com/IntersectMBO/developer-experience/issues) before opening a new one.
+4. Open an issue to discuss significant changes, then submit a pull request linked to that issue.
+
+Typical contributions include documentation fixes, new guides, code examples, and working-group session materials.
+
+## Contact
+
+| Channel | Link |
+| --- | --- |
+| GitHub Discussions | [developer-experience/discussions](https://github.com/IntersectMBO/developer-experience/discussions) |
+| Discord (OSC Working Groups) | [Join channel](https://discord.com/channels/1136727663583698984/1239886460266479696) |
+| Email | [oso@intersectmbo.org](mailto:oso@intersectmbo.org) |
 
 ---
 
-**Disclaimer**: This working group is community-driven and supported by Intersect MBO. We welcome contributions from all skill levels and backgrounds.
+This working group is community-driven and supported by Intersect MBO. We welcome contributions from all skill levels and backgrounds.
 
+**Disclaimer:** Content reflects community efforts and may evolve as the Cardano ecosystem grows. Report outdated information via [GitHub Issues](https://github.com/IntersectMBO/developer-experience/issues).
 
+## License
+
+This project is licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary

Refactors the repository README to improve clarity, navigation, and onboarding for new contributors. Addresses [#194](https://github.com/IntersectMBO/developer-experience/issues/194).

- Restructures the README with a clear overview, quick start, usage examples, and project structure
- Adds centered GitHub badges for repo metrics (stars, forks, issues, contributors) and project tags (website, deploy status, license, Node.js, Docusaurus)
- Moves **Developer Advocates** higher in the document for easier discovery
- Adds a 5-minute **Quick Start** for running the docs site locally
- Links setup instructions to [CONTRIBUTING.md](./CONTRIBUTING.md) instead of duplicating them
- Standardizes formatting with tables, code examples, and consistent section headings
- Fixes the broken website link (`https://devex.intersectmbo.org`)

## Changes

| Section | Change |
| --- | --- |
| Header | Added GitHub badges and a concise project description |
| Overview | Mission, focus areas table, and live site link |
| Developer Advocates | Moved up after Overview; current and past cohorts in tables |
| Quick Start | Clone → install → `npm run start:dev` workflow |
| Installation | Prerequisites table; setup points to Contributing Guide |
| Usage | Examples for editing docs and adding working-group sessions |
| Project Structure | Directory tree with descriptions |
| Documentation | Links to key guides on the site |
| Get Involved / Contributing / Contact | Preserved and reformatted for scanability |

## Test plan

- [ ] README renders correctly on GitHub (badges, tables, code blocks)
- [ ] All internal links resolve (`CONTRIBUTING.md`, `CODE-OF-CONDUCT.md`, `LICENSE`, docs paths)
- [ ] External links open correctly (website, calendar, advocate profiles, Discord)
- [ ] Quick Start commands match `website/package.json` scripts and Node.js 20+ requirement
- [ ] Developer Advocates contact info matches current cohort details