### PR TITLE
docs: add recording page for session 18 on Cardano MCP server develop…

### DIFF
--- a/website/docs/working-group/sessions/q2-2026/18-cardano-mcp-server/recordings/readme.md
+++ b/website/docs/working-group/sessions/q2-2026/18-cardano-mcp-server/recordings/readme.md
@@ -1,0 +1,27 @@
+---
+title: "Session 18: Building a Production-Grade MCP Server for Cardano - Recordings"
+sidebar_label: Recordings
+slug: /working-group/q2-2026/sessions/18-cardano-mcp-server/recordings
+---
+
+# Session 18: Building a Production-Grade MCP Server for Cardano - Recordings
+
+In this session we built and walked through [Cardano MCP](https://github.com/lidonation/Cardano-mcp), a purpose-built Model Context Protocol server that gives AI assistants like Claude live, idiomatic access to the Cardano blockchain. The session covers the eUTxO model, the 6-module 38-tool server architecture, multi-API routing across Blockfrost, Koios, Maestro and Kupo, CIP-1694 governance queries, and a full React demo app.
+
+For the full breakdown, architecture overview, and setup instructions, see the [Session Notes](../session-notes/readme.md).
+
+## Session 1
+
+<iframe
+  width="100%"
+  height="400"
+  src="https://www.youtube.com/embed/09NgEFLSkqc"
+  title="Session 18: Building a Production-Grade MCP Server for Cardano"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>
+
+---
+
+*This recording belongs to the Q2 2026 Developer Experience Working Group.*


### PR DESCRIPTION
#### **Description**

Adds the session recording for Session 18: Building a Production-Grade MCP Server for Cardano.

- Creates the recordings page for session 18 with the YouTube video embedded
- Adds a short context summary of what the session covers and links through to the full session notes

#### **Related Issue**

N/A

#### **Type of Change**

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor
- [ ] Other

#### **Changes Made**

- Added `website/docs/working-group/sessions/q2-2026/18-cardano-mcp-server/recordings/readme.md` — new recordings page with embedded YouTube iframe (`https://youtu.be/09NgEFLSkqc`), a brief session description, and a link to the session notes

#### **Checklist**

- [x] My code follows the project's coding style and guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked for merge conflicts.
- [x] I have rebased my branch onto the latest `main` or `master` branch.
