### PR TITLE
fix: replace broken file:// link with the public GitHub URL of the ca…

### DIFF
--- a/website/docs/working-group/sessions/q2-2026/15-dapp-architecture-demo/session-resources/readme.md
+++ b/website/docs/working-group/sessions/q2-2026/15-dapp-architecture-demo/session-resources/readme.md
@@ -16,7 +16,7 @@ Curated resources and tools for building full-stack dApps on Cardano.
 
 ## Demo Project
 
-*   **[Educational dApp Demo](file:///Users/tyty/Desktop/Demos/cardano-dapp-demo)**: The source code for the architecture demonstrated in this session.
+*   **[Educational dApp Demo](https://github.com/Emmanuel-Tyty/Demos/tree/main/cardano-dapp-demo)**: The source code for the architecture demonstrated in this session.
 
 ## Further Reading
 


### PR DESCRIPTION
#### **Description**
Replace broken `file://` demo link in Session 15 resources with the demo app GitHub URL.

#### **Related Issue**
`Related to #267 `

#### **Type of Change**

Check the type of change this PR introduces:
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor (improves code structure or readability without changing functionality)
- [ ] Other (please describe):

#### **Changes Made**

- Fixed broken `file://` link in Session 15 resources
- Replaced local `file:///Users/tyty/Desktop/Demos/cardano-dapp-demo` with the cardano-dapp-demo GitHub URL made by tyty: `https://github.com/Emmanuel-Tyty/Demos/tree/main/cardano-dapp-demo`

#### **Checklist**

Ensure you have completed the following steps before submitting your PR:
- [x] My code follows the project's coding style and guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have checked for merge conflicts.
- [ ] I have rebased my branch onto the latest `main` or `master` branch.

